### PR TITLE
Move the API into Next.js and restyle the app light and minimal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# MongoDB (same cluster/collections the Express backend used)
+SOCIALS_MONGO_DB_URL=
+
+# NextAuth / Google sign-in
+AUTH_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+
+# Public assets
+NEXT_PUBLIC_CDN_URL=

--- a/README.md
+++ b/README.md
@@ -1,36 +1,57 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+This is a [Next.js](https://nextjs.org) app that stores users and social handles in MongoDB.
 
-## Getting Started
+The previous Express backend is no longer required. All API routes live in this app under `/api/serverApi` so you can deploy the whole product on Vercel.
 
-First, run the development server:
+## Local development
 
 ```bash
+npm install
+cp .env.example .env.local
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Set these in `.env.local` and in the Vercel project settings:
 
-## Learn More
+| Variable | Purpose |
+| --- | --- |
+| `SOCIALS_MONGO_DB_URL` | MongoDB connection string (same database the Express app used) |
+| `AUTH_SECRET` | NextAuth secret |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+| `NEXTAUTH_URL` | App URL, e.g. `http://localhost:3000` or `https://your-app.vercel.app` |
+| `NEXT_PUBLIC_CDN_URL` | Cloudinary/CDN base URL for social logos |
 
-To learn more about Next.js, take a look at the following resources:
+`NEXT_PUBLIC_API_URL` is no longer used. Browser requests go to `/api/serverApi` on the same origin.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+MongoDB Atlas must allow the Vercel deployment IPs (or `0.0.0.0/0` if you accept that for a free-tier app).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/serverApi/auth/signin` | Find or create a user on Google sign-in |
+| `GET` | `/api/serverApi/socials/getDefault` | List social platforms |
+| `GET` | `/api/serverApi/socials/getSocial/:id` | Get one social platform |
+| `GET` | `/api/serverApi/users/:email` | Get a user by email |
+| `PUT` | `/api/serverApi/users` | Update name/username |
+| `POST` | `/api/serverApi/users/addHandle` | Add a social handle |
+| `GET` | `/api/serverApi/users/handles/:email` | Get handles by email |
+| `GET` | `/api/serverApi/users/handles/byId/:id` | Get public profile by user id |
+| `PUT` | `/api/serverApi/users/handles` | Update a handle |
+| `DELETE` | `/api/serverApi/users/handles` | Delete a handle |
+| `GET` | `/api/serverApi/health` | Mongo connectivity check |
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+1. Import this GitHub repo in Vercel.
+2. Add the environment variables above.
+3. Deploy. The app and API ship together; no separate backend service is needed.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm test
+npm run build
+```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // setup the image domain to https://randomuser.me/
+  experimental: {
+    serverComponentsExternalPackages: ["mongoose"]
+  },
   images: {
     remotePatterns: [
       {
@@ -10,10 +12,10 @@ const nextConfig = {
         pathname: "/a/**"
       },
       {
-        pathname:"https",
-        hostname:"res.cloudinary.com",
-        port:"",
-        pathname:"/**"
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+        port: "",
+        pathname: "/**"
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.439.0",
+        "mongoose": "^8.5.4",
         "next": "14.2.9",
         "next-auth": "^4.24.7",
         "next-pwa": "^5.6.0",
@@ -25,6 +26,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hot-toast": "^2.4.1",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -36,7 +38,8 @@
         "eslint-config-next": "14.2.9",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1757,6 +1760,397 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1962,9 +2356,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1973,6 +2368,32 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.5.0.tgz",
+      "integrity": "sha512-Hk1SKJCMcCos38+vqDnZzlIo4XRj9yCGzYkjB4LcqpeXRIYfia1UWTz+VrueLxoU+uSRJzgkufxoRZg8gi52YA==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@next/env": {
@@ -2835,6 +3256,356 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2884,10 +3655,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "peer": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -2965,6 +3736,21 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.2.0",
@@ -3185,6 +3971,149 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -3630,6 +4559,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3833,6 +4772,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3858,6 +4806,16 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -3914,6 +4872,23 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3927,6 +4902,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4201,6 +5186,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-equal": {
@@ -4593,8 +5588,7 @@
     "node_modules/es-module-lexer": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-      "peer": true
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -4643,6 +5637,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -5098,6 +6131,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -6391,6 +7434,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6532,6 +7584,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -6574,6 +7633,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6645,6 +7710,139 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.24.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.3.tgz",
+      "integrity": "sha512-CMHqVyjK0Szc6irT14+O+QpN30kHxJLa0FjjLiBz/Txivmfg3mUUdMWAXfYM1Ubl0SNUkcG2cyLKOnhvttLtOA==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -7153,6 +8351,23 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -8005,6 +9220,12 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -8071,6 +9292,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8125,6 +9359,29 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -8621,6 +9878,50 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -8962,6 +10263,211 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -9174,6 +10680,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",
@@ -26,6 +27,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hot-toast": "^2.4.1",
+    "server-only": "^0.0.1",
+    "mongoose": "^8.5.4",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"
   },
@@ -37,6 +40,7 @@
     "eslint-config-next": "14.2.9",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/app/(socials)/choose-socials/page.tsx
+++ b/src/app/(socials)/choose-socials/page.tsx
@@ -1,5 +1,7 @@
 import SocialsList from "@/app/components/ui/socialsList/socialsList";
 
+export const dynamic = "force-dynamic";
+
 const CreateSocials = async () => {
   return <SocialsList />;
 };

--- a/src/app/(socials)/new/[social]/page.tsx
+++ b/src/app/(socials)/new/[social]/page.tsx
@@ -1,10 +1,22 @@
 import SocialForm from "@/app/components/ui/socialForm/socialForm";
+import { dbConnect } from "@/lib/db/mongoose";
+import { getSocialById } from "@/lib/services/socials";
+import { Social as SocialModel } from "@/app/models/socials";
+
+export const dynamic = "force-dynamic";
 
 export default async function Social({ params }: { params: { social: string } }) {
-  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/socials/getSocial/${params.social}`, {
-    method: "GET"
-  });
-  const data = await response.json();
+  await dbConnect();
+  const response = await getSocialById(params.social);
+  const data = (response.body ?? {}) as SocialModel;
+
+  if (response.status !== 200 || !data?._id) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <p className="text-gray-700 dark:text-gray-300">Social platform not found.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/(user)/[userId]/page.tsx
+++ b/src/app/(user)/[userId]/page.tsx
@@ -1,16 +1,19 @@
 import ShareButton from "@/app/components/ui/shareButton/shareButton";
 import { USER_SOCIAL } from "@/app/models/socials";
-import { getUserHandlesUsingId } from "@/serverApi/Users/users";
-import { revalidatePath } from "next/cache";
+import { dbConnect } from "@/lib/db/mongoose";
+import { getUserHandlesById } from "@/lib/services/users";
 import Image from "next/image";
 
-export const revalidate = 10;
-export const dynamicParams = true; // or false, to 404 on unknown paths
+export const dynamic = "force-dynamic";
 
 const User = async ({ params }: { params: { userId: string } }) => {
-  revalidatePath(`/user/${params.userId}`);
-  const getUserData = await getUserHandlesUsingId({ id: params.userId });
-  const userHandles = getUserData.data;
+  await dbConnect();
+  const getUserData = await getUserHandlesById(params.userId);
+  const userHandles = getUserData.body as {
+    name?: string;
+    username?: string;
+    handles?: USER_SOCIAL[];
+  } | null;
 
   if (!userHandles?.handles?.length) {
     return (

--- a/src/app/api/serverApi/auth/signin/route.ts
+++ b/src/app/api/serverApi/auth/signin/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { loginUser } from "@/lib/services/auth";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  await dbConnect();
+  const body = await request.json();
+  const result = await loginUser({ email: body.email, name: body.name });
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/auth/signup/route.ts
+++ b/src/app/api/serverApi/auth/signup/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { signupUser } from "@/lib/services/auth";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handleSignup(request: NextRequest) {
+  await dbConnect();
+  let body: Record<string, unknown> = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const result = await signupUser(body);
+  return jsonResult(result);
+}
+
+export async function GET(request: NextRequest) {
+  return handleSignup(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleSignup(request);
+}

--- a/src/app/api/serverApi/health/route.ts
+++ b/src/app/api/serverApi/health/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    await dbConnect();
+    return NextResponse.json({ ok: true, mongo: "connected" });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Mongo connection failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/serverApi/socials/getDefault/route.ts
+++ b/src/app/api/serverApi/socials/getDefault/route.ts
@@ -1,0 +1,12 @@
+import { dbConnect } from "@/lib/db/mongoose";
+import { getDefaultSocials } from "@/lib/services/socials";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  await dbConnect();
+  const result = await getDefaultSocials();
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/socials/getSocial/[id]/route.ts
+++ b/src/app/api/serverApi/socials/getSocial/[id]/route.ts
@@ -1,0 +1,12 @@
+import { dbConnect } from "@/lib/db/mongoose";
+import { getSocialById } from "@/lib/services/socials";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  await dbConnect();
+  const result = await getSocialById(params.id);
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/socials/social/route.ts
+++ b/src/app/api/serverApi/socials/social/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { createSocial } from "@/lib/services/socials";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  await dbConnect();
+  const body = await request.json();
+  const result = await createSocial(body);
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/[email]/route.ts
+++ b/src/app/api/serverApi/users/[email]/route.ts
@@ -1,0 +1,12 @@
+import { dbConnect } from "@/lib/db/mongoose";
+import { getUserByEmail } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { email: string } }) {
+  await dbConnect();
+  const result = await getUserByEmail(decodeURIComponent(params.email));
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/addHandle/route.ts
+++ b/src/app/api/serverApi/users/addHandle/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { addHandle } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  await dbConnect();
+  const { userId, socialPlatformId, handle } = await request.json();
+  const result = await addHandle({ userId, socialPlatformId, handle });
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/handles/[email]/route.ts
+++ b/src/app/api/serverApi/users/handles/[email]/route.ts
@@ -1,0 +1,12 @@
+import { dbConnect } from "@/lib/db/mongoose";
+import { getUserHandlesByEmail } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { email: string } }) {
+  await dbConnect();
+  const result = await getUserHandlesByEmail(decodeURIComponent(params.email));
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/handles/byId/[id]/route.ts
+++ b/src/app/api/serverApi/users/handles/byId/[id]/route.ts
@@ -1,0 +1,12 @@
+import { dbConnect } from "@/lib/db/mongoose";
+import { getUserHandlesById } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  await dbConnect();
+  const result = await getUserHandlesById(params.id);
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/handles/route.ts
+++ b/src/app/api/serverApi/users/handles/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { deleteUserHandle, updateUserHandle } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function PUT(request: NextRequest) {
+  await dbConnect();
+  const { email, platformId, handle } = await request.json();
+  const result = await updateUserHandle({ email, platformId, handle });
+  return jsonResult(result);
+}
+
+export async function DELETE(request: NextRequest) {
+  await dbConnect();
+  const { email, platformId } = await request.json();
+  const result = await deleteUserHandle({ email, platformId });
+  return jsonResult(result);
+}

--- a/src/app/api/serverApi/users/route.ts
+++ b/src/app/api/serverApi/users/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { dbConnect } from "@/lib/db/mongoose";
+import { updateUser } from "@/lib/services/users";
+import { jsonResult } from "@/lib/api/respond";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function PUT(request: NextRequest) {
+  await dbConnect();
+  const { email, name, userName } = await request.json();
+  const result = await updateUser({ email, name, userName });
+  return jsonResult(result);
+}

--- a/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
@@ -1,5 +1,6 @@
 import { authConfig } from "@/auth";
-import { getUserHandles } from "@/serverApi/Users/users";
+import { dbConnect } from "@/lib/db/mongoose";
+import { getUserHandlesByEmail } from "@/lib/services/users";
 import { getServerSession } from "next-auth/next";
 import { redirect } from "next/navigation";
 import UserSocialCard from "@/app/components/ui/userSocialCard/userSocialCard";
@@ -7,18 +8,20 @@ import RedirectButton from "./redirectButton";
 import { USER_SOCIAL } from "@/app/models/socials";
 
 async function getUserInfo(email: string) {
-  try {
-    const response = await getUserHandles({ email });
+  await dbConnect();
+  const response = await getUserHandlesByEmail(email);
 
-    if (!response) {
-      throw new Error("Failed to fetch user info");
-    }
-
-    return response;
-  } catch (error) {
-    console.error("Error fetching user info:", error);
-    throw error; // Re-throw to be handled in the component
+  if (response.status !== 200 || !response.body) {
+    throw new Error("Failed to fetch user info");
   }
+
+  return response.body as {
+    userName?: string;
+    username?: string;
+    name: string;
+    handles: Array<USER_SOCIAL>;
+    _id: string;
+  };
 }
 
 const HomePageLoggedIn = async () => {
@@ -36,10 +39,10 @@ const HomePageLoggedIn = async () => {
   try {
     const userData = await getUserInfo(session.user?.email as string);
     userInfo = {
-      userName: userData.data.userName,
-      name: userData.data.name,
-      handles: userData.data.handles,
-      userId: userData.data._id
+      userName: userData.userName || userData.username || "",
+      name: userData.name,
+      handles: userData.handles,
+      userId: userData._id
     };
   } catch (error) {
     console.error("Error fetching user info:", error);

--- a/src/app/components/ui/socialsList/socialsList.tsx
+++ b/src/app/components/ui/socialsList/socialsList.tsx
@@ -1,9 +1,12 @@
 import { Social } from "@/app/models/socials";
+import { dbConnect } from "@/lib/db/mongoose";
+import { getDefaultSocials } from "@/lib/services/socials";
 import SocialCard from "../socialCard/socialCard";
 
 const SocialsList = async () => {
-  const socials = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/socials/getDefault`);
-  const data = await socials.json();
+  await dbConnect();
+  const socials = await getDefaultSocials();
+  const data = Array.isArray(socials.body) ? (socials.body as Social[]) : [];
 
   return (
     <div className="p-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,10 @@ import { authConfig } from "@/auth";
 import HomePageLoggedIn from "./components/layout/homePage/homePageLoggedIn/homePageLoggedIn";
 import { getServerSession } from "next-auth";
 import HomePageLoggedOut from "./components/layout/homePage/homePageLoggedOut/homePageLoggedOut";
-import { revalidatePath } from "next/cache";
 
-export const revalidate = 60;
+export const dynamic = "force-dynamic";
+
 export default async function Home() {
-  revalidatePath("/");
   // check if user logged in or not
 
   const session = await getServerSession(authConfig);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import GoogleProvider from "next-auth/providers/google";
-import { userLogin } from "./serverApi/Authentication/authentication";
 import { NextAuthOptions } from "next-auth";
+import { dbConnect } from "@/lib/db/mongoose";
+import { loginUser } from "@/lib/services/auth";
 
 const authConfig: NextAuthOptions = {
   secret: process.env.AUTH_SECRET,
@@ -17,7 +18,12 @@ const authConfig: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       if (account?.provider === "google") {
-        await userLogin({ userEmail: user.email || "", name: user.name || "" });
+        try {
+          await dbConnect();
+          await loginUser({ email: user.email || "", name: user.name || "" });
+        } catch (error) {
+          console.error("Failed to persist user on Google sign-in", error);
+        }
       }
       return true;
     }

--- a/src/lib/api/baseUrl.test.ts
+++ b/src/lib/api/baseUrl.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_BASE_PATH, getApiBaseUrl } from "./baseUrl";
+
+describe("getApiBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses a relative path in the browser", () => {
+    vi.stubGlobal("window", { document: {} });
+    expect(getApiBaseUrl()).toBe(API_BASE_PATH);
+  });
+
+  it("prefers NEXTAUTH_URL on the server", () => {
+    vi.stubEnv("NEXTAUTH_URL", "https://socials.example.com/");
+    expect(getApiBaseUrl()).toBe("https://socials.example.com/api/serverApi");
+  });
+
+  it("falls back to VERCEL_URL", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("VERCEL_URL", "socials.vercel.app");
+    expect(getApiBaseUrl()).toBe("https://socials.vercel.app/api/serverApi");
+  });
+
+  it("defaults to localhost during development", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+    vi.stubEnv("VERCEL_URL", "");
+    expect(getApiBaseUrl()).toBe("http://localhost:3000/api/serverApi");
+  });
+});

--- a/src/lib/api/baseUrl.ts
+++ b/src/lib/api/baseUrl.ts
@@ -1,0 +1,18 @@
+export const API_BASE_PATH = "/api/serverApi";
+
+export function getApiBaseUrl(): string {
+  if (typeof window !== "undefined") {
+    return API_BASE_PATH;
+  }
+
+  const siteUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (siteUrl) {
+    return `${siteUrl.replace(/\/$/, "")}${API_BASE_PATH}`;
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}${API_BASE_PATH}`;
+  }
+
+  return `http://localhost:3000${API_BASE_PATH}`;
+}

--- a/src/lib/api/respond.ts
+++ b/src/lib/api/respond.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import type { ServiceResult } from "@/lib/services/types";
+
+export function jsonResult<T>(result: ServiceResult<T>): NextResponse {
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export function jsonCaughtError(fallbackMessage: string, status = 500): NextResponse {
+  return NextResponse.json({ message: fallbackMessage }, { status });
+}

--- a/src/lib/db/models/social.ts
+++ b/src/lib/db/models/social.ts
@@ -1,0 +1,27 @@
+import mongoose, { Schema, models, model } from "mongoose";
+
+const SocialSchema = new Schema(
+  {
+    title: {
+      type: String,
+      required: true
+    },
+    socialLogo: {
+      type: String,
+      required: true
+    },
+    socialBaseUrl: {
+      type: String,
+      required: false
+    }
+  },
+  { collection: "socials" }
+);
+
+const Socials = models.Social || model("Social", SocialSchema);
+
+export type SocialDocument = mongoose.InferSchemaType<typeof SocialSchema> & {
+  _id: mongoose.Types.ObjectId;
+};
+
+export default Socials as mongoose.Model<SocialDocument>;

--- a/src/lib/db/models/user.ts
+++ b/src/lib/db/models/user.ts
@@ -1,0 +1,43 @@
+import mongoose, { Schema, models, model } from "mongoose";
+import type { SocialDocument } from "./social";
+
+const SocialHandleSchema = new Schema({
+  platform: { type: Schema.Types.ObjectId, ref: "Social" },
+  handle: { type: String, required: true }
+});
+
+const UserSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: true
+    },
+    email: {
+      type: String,
+      required: true,
+      unique: true
+    },
+    userName: {
+      type: String,
+      required: false,
+      unique: true
+    },
+    socialHandles: [SocialHandleSchema]
+  },
+  { collection: "users" }
+);
+
+const Users = models.User || model("User", UserSchema);
+
+export type SocialHandleDocument = {
+  _id: mongoose.Types.ObjectId;
+  platform?: mongoose.Types.ObjectId | SocialDocument | null;
+  handle: string;
+};
+
+export type UserDocument = mongoose.InferSchemaType<typeof UserSchema> & {
+  _id: mongoose.Types.ObjectId;
+  socialHandles: SocialHandleDocument[];
+};
+
+export default Users as mongoose.Model<UserDocument>;

--- a/src/lib/db/mongoose.ts
+++ b/src/lib/db/mongoose.ts
@@ -1,0 +1,45 @@
+import "server-only";
+import mongoose from "mongoose";
+
+interface MongooseCache {
+  conn: typeof mongoose | null;
+  promise: Promise<typeof mongoose> | null;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mongooseCache: MongooseCache | undefined;
+}
+
+const cached: MongooseCache = global.mongooseCache ?? { conn: null, promise: null };
+
+if (!global.mongooseCache) {
+  global.mongooseCache = cached;
+}
+
+export async function dbConnect(): Promise<typeof mongoose> {
+  const uri = process.env.SOCIALS_MONGO_DB_URL;
+
+  if (!uri) {
+    throw new Error("SOCIALS_MONGO_DB_URL is not defined");
+  }
+
+  if (cached.conn) {
+    return cached.conn;
+  }
+
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(uri, { bufferCommands: false });
+  }
+
+  cached.conn = await cached.promise;
+  return cached.conn;
+}
+
+export async function dbDisconnect(): Promise<void> {
+  if (cached.conn) {
+    await mongoose.disconnect();
+    cached.conn = null;
+    cached.promise = null;
+  }
+}

--- a/src/lib/services/auth.test.ts
+++ b/src/lib/services/auth.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/models/user", () => ({
+  default: {
+    findOne: vi.fn(),
+    create: vi.fn()
+  }
+}));
+
+import Users from "@/lib/db/models/user";
+import { loginUser, signupUser } from "./auth";
+
+describe("loginUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an existing user", async () => {
+    const existing = { _id: "1", email: "a@b.com", name: "A" };
+    vi.mocked(Users.findOne).mockResolvedValue(existing as never);
+
+    const result = await loginUser({ email: "a@b.com", name: "A" });
+
+    expect(Users.create).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 200, body: existing });
+  });
+
+  it("creates a user when none exists and returns the created document", async () => {
+    const created = { _id: "2", email: "new@b.com", name: "New" };
+    vi.mocked(Users.findOne).mockResolvedValue(null);
+    vi.mocked(Users.create).mockResolvedValue(created as never);
+
+    const result = await loginUser({ email: "new@b.com", name: "New" });
+
+    expect(Users.create).toHaveBeenCalledWith({ email: "new@b.com", name: "New" });
+    expect(result).toEqual({ status: 200, body: created });
+  });
+
+  it("returns a 500 payload on failure", async () => {
+    vi.mocked(Users.findOne).mockRejectedValue(new Error("db down"));
+
+    const result = await loginUser({ email: "a@b.com", name: "A" });
+
+    expect(result).toEqual({ status: 500, body: { error: "db down" } });
+  });
+});
+
+describe("signupUser", () => {
+  it("creates a user with a 201 status", async () => {
+    const created = { email: "a@b.com" };
+    vi.mocked(Users.create).mockResolvedValue(created as never);
+
+    await expect(signupUser({ email: "a@b.com", name: "A" })).resolves.toEqual({
+      status: 201,
+      body: created
+    });
+  });
+});

--- a/src/lib/services/auth.ts
+++ b/src/lib/services/auth.ts
@@ -1,0 +1,28 @@
+import Users from "@/lib/db/models/user";
+import { errorMessage, ServiceResult } from "./types";
+
+export type LoginInput = {
+  email: string;
+  name: string;
+};
+
+export async function loginUser({ email, name }: LoginInput): Promise<ServiceResult<unknown>> {
+  try {
+    let user = await Users.findOne({ email });
+    if (!user) {
+      user = await Users.create({ email, name });
+    }
+    return { status: 200, body: user };
+  } catch (error: unknown) {
+    return { status: 500, body: { error: errorMessage(error) } };
+  }
+}
+
+export async function signupUser(input: Record<string, unknown>): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.create(input);
+    return { status: 201, body: user };
+  } catch (error: unknown) {
+    return { status: 500, body: { error: errorMessage(error) } };
+  }
+}

--- a/src/lib/services/socials.test.ts
+++ b/src/lib/services/socials.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/models/social", () => ({
+  default: {
+    create: vi.fn(),
+    find: vi.fn(),
+    findById: vi.fn()
+  }
+}));
+
+import Socials from "@/lib/db/models/social";
+import { createSocial, getDefaultSocials, getSocialById } from "./socials";
+
+describe("social services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a social platform", async () => {
+    const created = { title: "GitHub" };
+    vi.mocked(Socials.create).mockResolvedValue(created as never);
+
+    await expect(createSocial({ title: "GitHub" })).resolves.toEqual({ status: 201, body: created });
+  });
+
+  it("lists default socials", async () => {
+    vi.mocked(Socials.find).mockResolvedValue([{ title: "X" }] as never);
+
+    await expect(getDefaultSocials()).resolves.toEqual({ status: 200, body: [{ title: "X" }] });
+  });
+
+  it("returns 404 when a social is missing", async () => {
+    vi.mocked(Socials.findById).mockResolvedValue(null);
+
+    await expect(getSocialById("missing")).resolves.toEqual({
+      status: 404,
+      body: { message: "Social not found" }
+    });
+  });
+});

--- a/src/lib/services/socials.ts
+++ b/src/lib/services/socials.ts
@@ -1,0 +1,32 @@
+import Socials from "@/lib/db/models/social";
+import { errorMessage, ServiceResult } from "./types";
+
+export async function createSocial(input: Record<string, unknown>): Promise<ServiceResult<unknown>> {
+  try {
+    const social = await Socials.create(input);
+    return { status: 201, body: social };
+  } catch (error: unknown) {
+    return { status: 500, body: { error: errorMessage(error) } };
+  }
+}
+
+export async function getDefaultSocials(): Promise<ServiceResult<unknown>> {
+  try {
+    const socials = await Socials.find();
+    return { status: 200, body: socials };
+  } catch (error: unknown) {
+    return { status: 500, body: { error: errorMessage(error) } };
+  }
+}
+
+export async function getSocialById(id: string): Promise<ServiceResult<unknown>> {
+  try {
+    const social = await Socials.findById(id);
+    if (!social) {
+      return { status: 404, body: { message: "Social not found" } };
+    }
+    return { status: 200, body: social };
+  } catch {
+    return { status: 404, body: { message: "Social not found" } };
+  }
+}

--- a/src/lib/services/types.test.ts
+++ b/src/lib/services/types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage, isDuplicateKeyError, platformIdOf } from "./types";
+
+describe("isDuplicateKeyError", () => {
+  it("detects Mongo duplicate key codes", () => {
+    expect(isDuplicateKeyError({ code: 11000 })).toBe(true);
+    expect(isDuplicateKeyError({ codeName: "DuplicateKey" })).toBe(true);
+    expect(isDuplicateKeyError({ code: 1 })).toBe(false);
+    expect(isDuplicateKeyError(null)).toBe(false);
+  });
+});
+
+describe("errorMessage", () => {
+  it("reads Error messages and falls back otherwise", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+    expect(errorMessage("nope", "fallback")).toBe("fallback");
+  });
+});
+
+describe("platformIdOf", () => {
+  it("reads populated platform documents and raw ObjectIds", () => {
+    expect(platformIdOf({ _id: { toString: () => "abc" } })).toBe("abc");
+    expect(platformIdOf({ toString: () => "raw-id" })).toBe("raw-id");
+    expect(platformIdOf(null)).toBe("");
+  });
+});

--- a/src/lib/services/types.ts
+++ b/src/lib/services/types.ts
@@ -1,0 +1,32 @@
+export type ServiceResult<T> = {
+  status: number;
+  body: T;
+};
+
+export function isDuplicateKeyError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const maybeError = error as { code?: number; codeName?: string };
+  return maybeError.code === 11000 || maybeError.codeName === "DuplicateKey";
+}
+
+export function errorMessage(error: unknown, fallback = "Server error"): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
+export function platformIdOf(platform: { _id?: { toString(): string } } | { toString(): string } | null | undefined): string {
+  if (!platform) {
+    return "";
+  }
+
+  if (typeof platform === "object" && "_id" in platform && platform._id) {
+    return platform._id.toString();
+  }
+
+  return platform.toString();
+}

--- a/src/lib/services/users.test.ts
+++ b/src/lib/services/users.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const populate = vi.fn();
+
+vi.mock("@/lib/db/models/user", () => ({
+  default: {
+    findOne: vi.fn(),
+    findById: vi.fn(),
+    findOneAndUpdate: vi.fn()
+  }
+}));
+
+vi.mock("@/lib/db/models/social", () => ({
+  default: {
+    findById: vi.fn()
+  }
+}));
+
+import Users from "@/lib/db/models/user";
+import Socials from "@/lib/db/models/social";
+import { addHandle, deleteUserHandle, getUserByEmail, getUserHandlesByEmail, getUserHandlesById, updateUser, updateUserHandle } from "./users";
+
+function populatedQuery(result: unknown) {
+  populate.mockResolvedValue(result);
+  return { populate };
+}
+
+describe("user services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 404 when a user is missing", async () => {
+    vi.mocked(Users.findOne).mockReturnValue(populatedQuery(null) as never);
+
+    await expect(getUserByEmail("missing@x.com")).resolves.toEqual({
+      status: 404,
+      body: { message: "User not found" }
+    });
+  });
+
+  it("returns a populated user", async () => {
+    const user = { email: "a@b.com", socialHandles: [] };
+    vi.mocked(Users.findOne).mockReturnValue(populatedQuery(user) as never);
+
+    await expect(getUserByEmail("a@b.com")).resolves.toEqual({ status: 200, body: user });
+  });
+
+  it("maps duplicate usernames to 400", async () => {
+    vi.mocked(Users.findOneAndUpdate).mockRejectedValue({ code: 11000 });
+
+    await expect(updateUser({ email: "a@b.com", name: "A", userName: "taken" })).resolves.toEqual({
+      status: 400,
+      body: { message: "Username already exists" }
+    });
+  });
+
+  it("rejects adding a handle when user or platform is missing", async () => {
+    vi.mocked(Users.findById).mockResolvedValue(null);
+    vi.mocked(Socials.findById).mockResolvedValue({ _id: "p1" } as never);
+
+    await expect(addHandle({ userId: "u1", socialPlatformId: "p1", handle: "me" })).resolves.toEqual({
+      status: 404,
+      body: { message: "User or Social Platform not found" }
+    });
+  });
+
+  it("rejects duplicate social handles", async () => {
+    const user = {
+      socialHandles: [{ platform: { toString: () => "p1" }, handle: "old" }],
+      save: vi.fn()
+    };
+    vi.mocked(Users.findById).mockResolvedValue(user as never);
+    vi.mocked(Socials.findById).mockResolvedValue({ _id: "p1" } as never);
+
+    await expect(addHandle({ userId: "u1", socialPlatformId: "p1", handle: "new" })).resolves.toEqual({
+      status: 400,
+      body: { message: "Social handle already exists" }
+    });
+    expect(user.save).not.toHaveBeenCalled();
+  });
+
+  it("adds a social handle", async () => {
+    const user = {
+      socialHandles: [] as Array<Record<string, unknown>>,
+      save: vi.fn().mockResolvedValue(undefined)
+    };
+    vi.mocked(Users.findById).mockResolvedValue(user as never);
+    vi.mocked(Socials.findById).mockResolvedValue({ _id: "p1" } as never);
+
+    const result = await addHandle({ userId: "u1", socialPlatformId: "p1", handle: "me" });
+
+    expect(user.socialHandles).toEqual([{ platform: "p1", handle: "me" }]);
+    expect(user.save).toHaveBeenCalled();
+    expect(result.status).toBe(200);
+  });
+
+  it("returns both username keys and the user id for handle lookups", async () => {
+    const user = { _id: "u1", userName: "karan", name: "Karan", socialHandles: [] };
+    vi.mocked(Users.findOne).mockReturnValue(populatedQuery(user) as never);
+    vi.mocked(Users.findById).mockReturnValue(populatedQuery(user) as never);
+
+    await expect(getUserHandlesByEmail("a@b.com")).resolves.toEqual({
+      status: 200,
+      body: { username: "karan", userName: "karan", name: "Karan", handles: [], _id: "u1" }
+    });
+    await expect(getUserHandlesById("u1")).resolves.toEqual({
+      status: 200,
+      body: { username: "karan", userName: "karan", name: "Karan", handles: [], _id: "u1" }
+    });
+  });
+
+  it("updates and deletes handles for an existing user", async () => {
+    const user = { email: "a@b.com" };
+    vi.mocked(Users.findOne).mockReturnValue(populatedQuery(user) as never);
+    vi.mocked(Users.findOneAndUpdate).mockResolvedValue({ email: "a@b.com", socialHandles: [] } as never);
+
+    await expect(updateUserHandle({ email: "a@b.com", platformId: "h1", handle: "new" })).resolves.toMatchObject({
+      status: 200,
+      body: { message: "Social handle updated successfully" }
+    });
+    await expect(deleteUserHandle({ email: "a@b.com", platformId: "h1" })).resolves.toMatchObject({
+      status: 200,
+      body: { message: "Social handle deleted successfully" }
+    });
+  });
+});

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -1,0 +1,158 @@
+import Users from "@/lib/db/models/user";
+import Socials from "@/lib/db/models/social";
+import { errorMessage, isDuplicateKeyError, platformIdOf, ServiceResult } from "./types";
+
+function toUserHandlesPayload(user: {
+  _id: { toString(): string };
+  userName?: string | null;
+  name?: string | null;
+  socialHandles: unknown;
+}) {
+  return {
+    username: user.userName,
+    userName: user.userName,
+    name: user.name,
+    handles: user.socialHandles,
+    _id: user._id
+  };
+}
+
+export async function getUserByEmail(email: string): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findOne({ email }).populate("socialHandles.platform");
+    if (!user) {
+      return { status: 404, body: { message: "User not found" } };
+    }
+    return { status: 200, body: user };
+  } catch {
+    return { status: 404, body: { message: "User not found" } };
+  }
+}
+
+export async function updateUser({
+  email,
+  name,
+  userName
+}: {
+  email: string;
+  name: string;
+  userName: string;
+}): Promise<ServiceResult<unknown>> {
+  try {
+    const updatedUser = await Users.findOneAndUpdate({ email }, { $set: { name, userName } }, { new: true });
+    return { status: 200, body: { message: "User updated successfully", data: updatedUser } };
+  } catch (error: unknown) {
+    if (isDuplicateKeyError(error)) {
+      return { status: 400, body: { message: "Username already exists" } };
+    }
+    return { status: 500, body: { message: "Something went wrong", error } };
+  }
+}
+
+export async function addHandle({
+  userId,
+  socialPlatformId,
+  handle
+}: {
+  userId: string;
+  socialPlatformId: string;
+  handle: string;
+}): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findById(userId);
+    const socialPlatform = await Socials.findById(socialPlatformId);
+
+    if (!user || !socialPlatform) {
+      return { status: 404, body: { message: "User or Social Platform not found" } };
+    }
+
+    const existingHandle = user.socialHandles.find((socialHandle) => platformIdOf(socialHandle.platform) === socialPlatformId);
+    if (existingHandle) {
+      return { status: 400, body: { message: "Social handle already exists" } };
+    }
+
+    user.socialHandles.push({
+      platform: socialPlatform._id,
+      handle
+    } as (typeof user.socialHandles)[number]);
+
+    await user.save();
+    return { status: 200, body: { message: "Social handle added successfully", user } };
+  } catch (error: unknown) {
+    return { status: 500, body: { message: "Server error", error } };
+  }
+}
+
+export async function getUserHandlesByEmail(email: string): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findOne({ email }).populate("socialHandles.platform");
+    if (!user) {
+      return { status: 404, body: { message: "User not found" } };
+    }
+    return { status: 200, body: toUserHandlesPayload(user) };
+  } catch {
+    return { status: 404, body: { message: "User not found" } };
+  }
+}
+
+export async function getUserHandlesById(id: string): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findById(id).populate("socialHandles.platform");
+    if (!user) {
+      return { status: 404, body: { message: "User not found" } };
+    }
+    return { status: 200, body: toUserHandlesPayload(user) };
+  } catch {
+    return { status: 404, body: { message: "User not found" } };
+  }
+}
+
+export async function updateUserHandle({
+  email,
+  platformId,
+  handle
+}: {
+  email: string;
+  platformId: string;
+  handle: string;
+}): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findOne({ email }).populate("socialHandles.platform");
+    if (!user) {
+      return { status: 404, body: { message: "User not found" } };
+    }
+
+    const updatedUser = await Users.findOneAndUpdate(
+      {
+        email,
+        "socialHandles._id": platformId
+      },
+      {
+        $set: {
+          "socialHandles.$.handle": handle
+        }
+      },
+      { new: true }
+    );
+
+    return { status: 200, body: { message: "Social handle updated successfully", data: updatedUser } };
+  } catch (error: unknown) {
+    return { status: 500, body: { message: "Server error", error } };
+  }
+}
+
+export async function deleteUserHandle({ email, platformId }: { email: string; platformId: string }): Promise<ServiceResult<unknown>> {
+  try {
+    const user = await Users.findOne({ email }).populate("socialHandles.platform");
+    if (!user) {
+      return { status: 404, body: { message: "User not found" } };
+    }
+
+    const updated = await Users.findOneAndUpdate({ email }, { $pull: { socialHandles: { _id: platformId } } }, { new: true });
+    return { status: 200, body: { message: "Social handle deleted successfully", data: updated } };
+  } catch (error: unknown) {
+    return { status: 500, body: { message: "Server error", error } };
+  }
+}
+
+export { errorMessage };

--- a/src/serverApi/Authentication/authentication.ts
+++ b/src/serverApi/Authentication/authentication.ts
@@ -1,20 +1,19 @@
+import { getApiBaseUrl } from "@/lib/api/baseUrl";
 import { signinProps } from "./model";
 
-export const userLogin = async ({ userEmail,name }: signinProps) => {
+export const userLogin = async ({ userEmail, name }: signinProps) => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signin`, {
+    const response = await fetch(`${getApiBaseUrl()}/auth/signin`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
       },
-      body: JSON.stringify({ email:userEmail, name })
+      body: JSON.stringify({ email: userEmail, name })
     });
 
     const data = await response.json();
-    console.log("ALL OK WITH SIGNIN", data);
     return data;
   } catch (error) {
-    console.log("ERROR WITH SIGNIN", error);
     console.error(error);
     return null;
   }

--- a/src/serverApi/Users/users.ts
+++ b/src/serverApi/Users/users.ts
@@ -1,10 +1,10 @@
-// @typescript-eslint/no-explicit-any
 import { Social } from "@/app/models/socials";
+import { getApiBaseUrl } from "@/lib/api/baseUrl";
 import { ApiResponse } from "../models/serverApi";
 
 export const getUser = async ({ email }: { email: string }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/${email}`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/${encodeURIComponent(email)}`, {
       method: "GET"
     });
 
@@ -27,7 +27,7 @@ export const getUser = async ({ email }: { email: string }): Promise<ApiResponse
 
 export const getUserHandles = async ({ email }: { email: string }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/handles/${email}`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/handles/${encodeURIComponent(email)}`, {
       method: "GET"
     });
 
@@ -51,7 +51,7 @@ export const getUserHandles = async ({ email }: { email: string }): Promise<ApiR
 
 export const getUserHandlesUsingId = async ({ id }: { id: string }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/handles/byId/${id}`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/handles/byId/${id}`, {
       method: "GET"
     });
 
@@ -75,7 +75,7 @@ export const getUserHandlesUsingId = async ({ id }: { id: string }): Promise<Api
 
 export const addUserHandle = async ({ socialData, formData }: { socialData: Social; formData: any }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/addHandle`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/addHandle`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
@@ -87,7 +87,6 @@ export const addUserHandle = async ({ socialData, formData }: { socialData: Soci
       })
     });
     const data = await response.json();
-    console.log("DATA IS ,", data);
     return {
       status: response.status,
       success: response.ok,
@@ -95,7 +94,6 @@ export const addUserHandle = async ({ socialData, formData }: { socialData: Soci
       data
     };
   } catch (error: any) {
-    console.log("ERROR ", error);
     return {
       status: error?.status || 500,
       success: false,
@@ -107,7 +105,7 @@ export const addUserHandle = async ({ socialData, formData }: { socialData: Soci
 
 export const updateUserHandle = async ({ email, platformId, handle }: { email: string; platformId: string; handle: string }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/handles`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/handles`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json"
@@ -135,7 +133,7 @@ export const updateUserHandle = async ({ email, platformId, handle }: { email: s
 
 export const deleteUserHandle = async ({ email, platformId }: { email: string; platformId: string }) => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/handles`, {
+    const response = await fetch(`${getApiBaseUrl()}/users/handles`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json"
@@ -163,7 +161,7 @@ export const deleteUserHandle = async ({ email, platformId }: { email: string; p
 
 export const updateUserInfo = async ({ email, name, userName }: { email: string; name: string; userName: string }): Promise<ApiResponse> => {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users`, {
+    const response = await fetch(`${getApiBaseUrl()}/users`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src")
+    }
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Express backend is no longer required. MongoDB access now lives in this Next.js app so the whole product can deploy on Vercel. The UI is now a light, minimal layout with clearer navigation.

## Why
The separate backend was down and blocking the app. Vercel can host Next.js for free, and the same Mongo cluster works from API routes.

## UI
- Light theme only (removed the forced `dark` class)
- Sticky header with **Add** and **My page** in the open, not only in the avatar menu
- Shorter home, empty state with one CTA, tap-a-row to add a platform
- Public page is a simple list of links

## Live 500 on `/api/serverApi/auth/signin`
If you still see `querySrv ENOTFOUND`, `SOCIALS_MONGO_DB_URL` points at a hostname that does not resolve. Copy a fresh Atlas connection string, update Vercel env, redeploy. `GET /api/serverApi/health` should return `{ "ok": true }`.

## Vercel env vars
- `SOCIALS_MONGO_DB_URL`
- `AUTH_SECRET`
- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
- `NEXTAUTH_URL`
- `NEXT_PUBLIC_CDN_URL`

## Verification
- `npx vitest run` — 25 tests passed
- `npx next lint` — clean
- `npx tsc --noEmit` — passed
- `npx next build` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a79c360-c535-4949-99c9-74ba5ffbcbda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a79c360-c535-4949-99c9-74ba5ffbcbda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

