### PR TITLE
Light UI, landing page, and clearer forms

### DIFF
--- a/src/app/(socials)/new/[social]/page.tsx
+++ b/src/app/(socials)/new/[social]/page.tsx
@@ -2,6 +2,8 @@ import SocialForm from "@/app/components/ui/socialForm/socialForm";
 import { dbConnect } from "@/lib/db/mongoose";
 import { getSocialById } from "@/lib/services/socials";
 import { Social as SocialModel } from "@/app/models/socials";
+import { PageShell } from "@/app/components/layout/pageShell";
+import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
@@ -12,26 +14,27 @@ export default async function Social({ params }: { params: { social: string } })
 
   if (response.status !== 200 || !data?._id) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <p className="text-gray-700 dark:text-gray-300">Social platform not found.</p>
-      </div>
+      <PageShell width="narrow" className="text-center">
+        <p>That platform was not found.</p>
+        <Link href="/choose-socials" className="mt-4 inline-block text-sm text-muted-foreground hover:text-foreground">
+          Choose another
+        </Link>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-16 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-4xl w-full mx-auto bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg">
-        {/* Title Section */}
-        <div className="text-center mb-6">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">Create Your Social</h1>
-          <p className="text-gray-600 dark:text-gray-400">
-            Fill out the form below to add your handle and redirect URL for {data.title}.
-          </p>
-        </div>
-
-        {/* Social Form */}
-        <SocialForm socialData={data} />
-      </div>
-    </div>
+    <PageShell width="narrow">
+      <p className="mb-2 text-sm text-muted-foreground">
+        <Link href="/choose-socials" className="hover:text-foreground">
+          Add
+        </Link>
+        <span className="mx-2">/</span>
+        {data.title}
+      </p>
+      <h1 className="text-2xl font-semibold tracking-tight">Add {data.title}</h1>
+      <p className="mt-1 mb-8 text-sm text-muted-foreground">Enter the username people should find you by.</p>
+      <SocialForm socialData={data} />
+    </PageShell>
   );
 }

--- a/src/app/(user)/[userId]/page.tsx
+++ b/src/app/(user)/[userId]/page.tsx
@@ -3,6 +3,7 @@ import { USER_SOCIAL } from "@/app/models/socials";
 import { dbConnect } from "@/lib/db/mongoose";
 import { getUserHandlesById } from "@/lib/services/users";
 import Image from "next/image";
+import { PageShell } from "@/app/components/layout/pageShell";
 
 export const dynamic = "force-dynamic";
 
@@ -17,48 +18,40 @@ const User = async ({ params }: { params: { userId: string } }) => {
 
   if (!userHandles?.handles?.length) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 transition-colors p-4">
-        <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 max-w-lg w-full transition-colors">
-          <div className="text-center mb-6">
-            <h1 className="text-2xl font-semibold text-gray-800 dark:text-white">You dont have any social handles yet.</h1>
-          </div>
-        </div>
-      </div>
+      <PageShell width="narrow" className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Nothing here yet</h1>
+        <p className="mt-2 text-sm text-muted-foreground">This page has no socials to show.</p>
+      </PageShell>
     );
   }
 
   return (
-    <>
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 transition-colors p-4">
-        <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 max-w-lg w-full transition-colors">
-          {/* User Info */}
-          <div className="text-center mb-6">
-            <h1 className="text-2xl font-semibold text-gray-800 dark:text-white">{userHandles.name}</h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400">@{userHandles.username}</p>
-          </div>
-
-          {/* Social Handles */}
-          <div className="space-y-4">
-            {userHandles.handles.map((handleObj: USER_SOCIAL) => (
-              <a
-                key={handleObj._id}
-                href={`${handleObj.platform.socialBaseUrl}${handleObj.handle}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center space-x-4 bg-gray-100 dark:bg-gray-700 p-3 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition"
-              >
-                <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handleObj.platform.socialLogo}`} alt={handleObj.platform.title} width={32} height={32} className="rounded-full" />
-                <div>
-                  <p className="text-lg font-medium text-gray-800 dark:text-white">{handleObj.platform.title}</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">{handleObj.handle}</p>
-                </div>
-              </a>
-            ))}
-            <ShareButton />
-          </div>
-        </div>
+    <PageShell width="narrow">
+      <div className="mb-8 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">{userHandles.name}</h1>
+        {userHandles.username && <p className="mt-1 text-sm text-muted-foreground">@{userHandles.username}</p>}
       </div>
-    </>
+      <div className="space-y-2">
+        {userHandles.handles.map((handleObj: USER_SOCIAL) => (
+          <a
+            key={handleObj._id}
+            href={`${handleObj.platform.socialBaseUrl}${handleObj.handle}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 rounded-2xl border bg-card px-4 py-3 transition-colors hover:bg-muted"
+          >
+            <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handleObj.platform.socialLogo}`} alt="" width={32} height={32} className="rounded-full" />
+            <div className="min-w-0">
+              <p className="font-medium leading-tight">{handleObj.platform.title}</p>
+              <p className="truncate text-sm text-muted-foreground">{handleObj.handle}</p>
+            </div>
+          </a>
+        ))}
+      </div>
+      <div className="mt-8 flex justify-center">
+        <ShareButton />
+      </div>
+    </PageShell>
   );
 };
 

--- a/src/app/(user)/[userId]/page.tsx
+++ b/src/app/(user)/[userId]/page.tsx
@@ -4,6 +4,7 @@ import { dbConnect } from "@/lib/db/mongoose";
 import { getUserHandlesById } from "@/lib/services/users";
 import Image from "next/image";
 import { PageShell } from "@/app/components/layout/pageShell";
+import { ArrowUpRight } from "lucide-react";
 
 export const dynamic = "force-dynamic";
 
@@ -31,20 +32,23 @@ const User = async ({ params }: { params: { userId: string } }) => {
         <h1 className="text-2xl font-semibold tracking-tight">{userHandles.name}</h1>
         {userHandles.username && <p className="mt-1 text-sm text-muted-foreground">@{userHandles.username}</p>}
       </div>
-      <div className="space-y-2">
+      <div className="space-y-3">
         {userHandles.handles.map((handleObj: USER_SOCIAL) => (
           <a
             key={handleObj._id}
             href={`${handleObj.platform.socialBaseUrl}${handleObj.handle}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-3 rounded-2xl border bg-card px-4 py-3 transition-colors hover:bg-muted"
+            className="group flex items-center gap-3 rounded-2xl border bg-card px-4 py-3.5 shadow-sm transition-all hover:-translate-y-px hover:shadow-md"
           >
-            <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handleObj.platform.socialLogo}`} alt="" width={32} height={32} className="rounded-full" />
-            <div className="min-w-0">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted">
+              <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handleObj.platform.socialLogo}`} alt="" width={28} height={28} className="rounded-md" />
+            </div>
+            <div className="min-w-0 flex-1">
               <p className="font-medium leading-tight">{handleObj.platform.title}</p>
               <p className="truncate text-sm text-muted-foreground">{handleObj.handle}</p>
             </div>
+            <ArrowUpRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
           </a>
         ))}
       </div>

--- a/src/app/(user)/profile/page.tsx
+++ b/src/app/(user)/profile/page.tsx
@@ -1,15 +1,9 @@
 "use client";
+
 import Profile from "@/app/components/layout/profile/profile";
-import { SessionProvider } from "next-auth/react";
 
 const ProfilePage = () => {
-  return (
-    <div>
-      <SessionProvider>
-        <Profile />
-      </SessionProvider>
-    </div>
-  );
+  return <Profile />;
 };
 
 export default ProfilePage;

--- a/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
@@ -67,7 +67,7 @@ const HomePageLoggedIn = async () => {
       </div>
 
       {handles.length === 0 ? (
-        <div className="rounded-2xl border border-dashed px-6 py-16 text-center">
+        <div className="rounded-2xl border border-dashed bg-card px-6 py-16 text-center shadow-sm">
           <p className="font-medium">No links yet</p>
           <p className="mt-1 text-sm text-muted-foreground">Add Instagram, GitHub, or anything else you share.</p>
           <Button asChild className="mt-6">

--- a/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedIn/homePageLoggedIn.tsx
@@ -6,6 +6,9 @@ import { redirect } from "next/navigation";
 import UserSocialCard from "@/app/components/ui/userSocialCard/userSocialCard";
 import RedirectButton from "./redirectButton";
 import { USER_SOCIAL } from "@/app/models/socials";
+import { PageShell } from "@/app/components/layout/pageShell";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 async function getUserInfo(email: string) {
   await dbConnect();
@@ -28,11 +31,8 @@ const HomePageLoggedIn = async () => {
   const session = await getServerSession(authConfig);
 
   if (!session) {
-    // redirect("/api/auth/signin");
-    // localStorage.removeItem("dbUserData");
     redirect("/");
-
-    return null; // Ensure no further rendering occurs after redirect
+    return null;
   }
 
   let userInfo: { userId: string; userName: string; name: string; handles: Array<USER_SOCIAL> } | null = null;
@@ -48,26 +48,40 @@ const HomePageLoggedIn = async () => {
     console.error("Error fetching user info:", error);
   }
 
+  const firstName = userInfo?.name?.split(" ")[0] || "there";
+  const handles = userInfo?.handles ?? [];
+
   return (
-    <div className="min-h-screen ">
-      {userInfo ? (
-        <div className="w-full h-full mx-auto p-4">
-          <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-6 text-center lg:text-left">Welcome, {userInfo.name}!</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-            {userInfo.handles?.map((handle: USER_SOCIAL) => (
-              <UserSocialCard key={handle._id} handle={handle} />
-            ))}
-          </div>
-          <div className="mt-4">
-            <RedirectButton />
-          </div>
+    <PageShell>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Hi, {firstName}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Your socials, ready to share.</p>
+        </div>
+        <div className="flex gap-2">
+          <Button asChild variant="outline">
+            <Link href="/choose-socials">Add</Link>
+          </Button>
+          {userInfo?.userId && <RedirectButton userId={userInfo.userId} />}
+        </div>
+      </div>
+
+      {handles.length === 0 ? (
+        <div className="rounded-2xl border border-dashed px-6 py-16 text-center">
+          <p className="font-medium">No links yet</p>
+          <p className="mt-1 text-sm text-muted-foreground">Add Instagram, GitHub, or anything else you share.</p>
+          <Button asChild className="mt-6">
+            <Link href="/choose-socials">Add a social</Link>
+          </Button>
         </div>
       ) : (
-        <div className="text-lg text-gray-700 dark:text-gray-300">
-          <p>Loading user information...</p>
+        <div className="space-y-3">
+          {handles.map((handle: USER_SOCIAL) => (
+            <UserSocialCard key={handle._id} handle={handle} />
+          ))}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 };
 

--- a/src/app/components/layout/homePage/homePageLoggedIn/redirectButton.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedIn/redirectButton.tsx
@@ -1,18 +1,16 @@
 "use client";
+
 import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
-import React from "react";
+const RedirectButton = ({ userId }: { userId?: string }) => {
+  const href = userId ? `/${userId}` : "/";
 
-const RedirectButton = () => {
-  const navigate = useRouter();
-  
-  const navigateUser = () => {
-    const userInfo = JSON.parse(localStorage.getItem("dbUserData") || "{}");
-    navigate.push(`${userInfo?._id}`);
-  }
-
-  return <Button onClick={navigateUser}>Visit your public page</Button>;
+  return (
+    <Button asChild variant="outline">
+      <Link href={href}>View public page</Link>
+    </Button>
+  );
 };
 
 export default RedirectButton;

--- a/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
@@ -1,4 +1,5 @@
 import JoinUsButton from "./joinUsButton";
+import { LandingPreview } from "./landingPreview";
 import { PageShell } from "@/app/components/layout/pageShell";
 import { Link2, Pencil, Share2 } from "lucide-react";
 
@@ -20,49 +21,52 @@ const steps = [
   }
 ];
 
+const fadeUp = (delayMs: number) =>
+  ({
+    animationDelay: `${delayMs}ms`
+  }) as const;
+
 const HomePageLoggedOut = () => {
   return (
     <PageShell width="wide" className="pb-20">
       <section className="mx-auto max-w-2xl pt-6 text-center sm:pt-10">
-        <p className="text-sm font-medium text-muted-foreground">A public page for your online self</p>
-        <h1 className="mt-3 text-4xl font-semibold tracking-tight sm:text-5xl">
+        <p className="motion-safe:animate-fade-up text-sm font-medium text-muted-foreground" style={fadeUp(0)}>
+          A public page for your online self
+        </p>
+        <h1 className="motion-safe:animate-fade-up mt-3 text-4xl font-semibold tracking-tight sm:text-5xl" style={fadeUp(80)}>
           All your socials,
           <br />
           one simple link.
         </h1>
-        <p className="mx-auto mt-5 max-w-lg text-base leading-relaxed text-muted-foreground">
+        <p
+          className="motion-safe:animate-fade-up mx-auto mt-5 max-w-lg text-base leading-relaxed text-muted-foreground"
+          style={fadeUp(160)}
+        >
           socials is a lightweight page you control. Collect the profiles you already have, then share a single URL instead of a list of usernames.
         </p>
-        <div className="mt-8 flex flex-col items-center gap-3">
+        <div className="motion-safe:animate-fade-up mt-8 flex flex-col items-center gap-3" style={fadeUp(240)}>
           <JoinUsButton />
           <p className="text-xs text-muted-foreground">Free. Takes about a minute.</p>
         </div>
       </section>
 
-      <section className="mx-auto mt-16 max-w-sm">
-        <div className="rounded-2xl border bg-card p-5 shadow-sm">
-          <div className="mb-4 text-center">
-            <p className="font-medium">Your name</p>
-            <p className="text-sm text-muted-foreground">@yourname</p>
-          </div>
-          <div className="space-y-2">
-            {["Instagram", "GitHub", "LinkedIn"].map((name) => (
-              <div key={name} className="flex items-center justify-between rounded-xl bg-muted/80 px-4 py-3 text-sm">
-                <span>{name}</span>
-                <span className="text-muted-foreground">Open →</span>
-              </div>
-            ))}
-          </div>
-        </div>
+      <section className="motion-safe:animate-fade-up mx-auto mt-16 max-w-sm" style={fadeUp(320)}>
+        <LandingPreview />
       </section>
 
       <section className="mt-20">
-        <h2 className="text-center text-xl font-semibold tracking-tight">How it works</h2>
+        <h2 className="motion-safe:animate-fade-up text-center text-xl font-semibold tracking-tight" style={fadeUp(400)}>
+          How it works
+        </h2>
         <div className="mt-8 grid gap-4 sm:grid-cols-3">
           {steps.map((step, index) => (
-            <div key={step.title} className="rounded-2xl border bg-card p-5 shadow-sm">
+            <div
+              key={step.title}
+              className="group motion-safe:animate-fade-up rounded-2xl border bg-card p-5 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
+              style={fadeUp(480 + index * 80)}
+            >
               <p className="text-xs font-medium text-muted-foreground">Step {index + 1}</p>
-              <step.icon className="mt-3 h-5 w-5" strokeWidth={1.75} />
+              <step.icon className="mt-3 h-5 w-5 transition-transform duration-200 group-hover:scale-110" strokeWidth={1.75} />
               <h3 className="mt-3 font-medium">{step.title}</h3>
               <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{step.body}</p>
             </div>
@@ -70,7 +74,10 @@ const HomePageLoggedOut = () => {
         </div>
       </section>
 
-      <section className="mt-16 rounded-2xl border bg-card px-6 py-10 text-center shadow-sm">
+      <section
+        className="motion-safe:animate-fade-up mt-16 rounded-2xl border bg-card px-6 py-10 text-center shadow-sm transition-shadow duration-200 hover:shadow-md"
+        style={fadeUp(740)}
+      >
         <h2 className="text-xl font-semibold tracking-tight">Ready to put everything in one place?</h2>
         <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
           Sign in, add a couple of handles, and you have a page you can send to anyone.

--- a/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
@@ -1,31 +1,16 @@
-import React from "react";
 import JoinUsButton from "./joinUsButton";
+import { PageShell } from "@/app/components/layout/pageShell";
 
 const HomePageLoggedOut = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-      <div className="text-center max-w-xl mx-auto p-6 space-y-6">
-        <h1 className="text-3xl font-bold text-gray-800 dark:text-white">
-          Welcome to <span className="text-blue-500">Socials</span>
-        </h1>
-
-        <p className="text-gray-600 dark:text-gray-300">
-          Easily share and manage all your social media profiles in one place.
-        </p>
-
-        <p className="text-gray-600 dark:text-gray-300">
-          <span className="font-semibold">Connect</span>, <span className="font-semibold">share</span>, and make it easier for others to find your social presence across platforms.
-        </p>
-
-        <p className="text-gray-600 dark:text-gray-300">
-          Ready to get started? Sign up today and start sharing your socials with the world!
-        </p>
-
-        <div>
-          <JoinUsButton />
-        </div>
+    <PageShell width="narrow" className="flex min-h-[70vh] flex-col items-center justify-center text-center">
+      <p className="mb-3 text-sm font-medium text-muted-foreground">Socials</p>
+      <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">All your links, one page.</h1>
+      <p className="mt-4 text-muted-foreground">Add your handles, share one URL.</p>
+      <div className="mt-8">
+        <JoinUsButton />
       </div>
-    </div>
+    </PageShell>
   );
 };
 

--- a/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/homePageLoggedOut.tsx
@@ -1,15 +1,84 @@
 import JoinUsButton from "./joinUsButton";
 import { PageShell } from "@/app/components/layout/pageShell";
+import { Link2, Pencil, Share2 } from "lucide-react";
+
+const steps = [
+  {
+    icon: Link2,
+    title: "Sign in",
+    body: "Use Google. We create your page — no extra account to remember."
+  },
+  {
+    icon: Pencil,
+    title: "Add your handles",
+    body: "Pick Instagram, GitHub, LinkedIn, and the rest. Type the username you already use."
+  },
+  {
+    icon: Share2,
+    title: "Share one URL",
+    body: "Put it in a bio, resume, or chat. People tap through to every profile from one place."
+  }
+];
 
 const HomePageLoggedOut = () => {
   return (
-    <PageShell width="narrow" className="flex min-h-[70vh] flex-col items-center justify-center text-center">
-      <p className="mb-3 text-sm font-medium text-muted-foreground">Socials</p>
-      <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">All your links, one page.</h1>
-      <p className="mt-4 text-muted-foreground">Add your handles, share one URL.</p>
-      <div className="mt-8">
-        <JoinUsButton />
-      </div>
+    <PageShell width="wide" className="pb-20">
+      <section className="mx-auto max-w-2xl pt-6 text-center sm:pt-10">
+        <p className="text-sm font-medium text-muted-foreground">A public page for your online self</p>
+        <h1 className="mt-3 text-4xl font-semibold tracking-tight sm:text-5xl">
+          All your socials,
+          <br />
+          one simple link.
+        </h1>
+        <p className="mx-auto mt-5 max-w-lg text-base leading-relaxed text-muted-foreground">
+          socials is a lightweight page you control. Collect the profiles you already have, then share a single URL instead of a list of usernames.
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <JoinUsButton />
+          <p className="text-xs text-muted-foreground">Free. Takes about a minute.</p>
+        </div>
+      </section>
+
+      <section className="mx-auto mt-16 max-w-sm">
+        <div className="rounded-2xl border bg-card p-5 shadow-sm">
+          <div className="mb-4 text-center">
+            <p className="font-medium">Your name</p>
+            <p className="text-sm text-muted-foreground">@yourname</p>
+          </div>
+          <div className="space-y-2">
+            {["Instagram", "GitHub", "LinkedIn"].map((name) => (
+              <div key={name} className="flex items-center justify-between rounded-xl bg-muted/80 px-4 py-3 text-sm">
+                <span>{name}</span>
+                <span className="text-muted-foreground">Open →</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-20">
+        <h2 className="text-center text-xl font-semibold tracking-tight">How it works</h2>
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          {steps.map((step, index) => (
+            <div key={step.title} className="rounded-2xl border bg-card p-5 shadow-sm">
+              <p className="text-xs font-medium text-muted-foreground">Step {index + 1}</p>
+              <step.icon className="mt-3 h-5 w-5" strokeWidth={1.75} />
+              <h3 className="mt-3 font-medium">{step.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{step.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-16 rounded-2xl border bg-card px-6 py-10 text-center shadow-sm">
+        <h2 className="text-xl font-semibold tracking-tight">Ready to put everything in one place?</h2>
+        <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+          Sign in, add a couple of handles, and you have a page you can send to anyone.
+        </p>
+        <div className="mt-6">
+          <JoinUsButton />
+        </div>
+      </section>
     </PageShell>
   );
 };

--- a/src/app/components/layout/homePage/homePageLoggedOut/joinUsButton.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/joinUsButton.tsx
@@ -2,11 +2,17 @@
 
 import { Button } from "@/components/ui/button";
 import { signIn } from "next-auth/react";
+import { ArrowRight } from "lucide-react";
 
 const JoinUsButton = () => {
   return (
-    <Button size="lg" className="px-6" onClick={() => signIn("google")}>
+    <Button
+      size="lg"
+      className="group px-6 transition-transform duration-200 hover:scale-[1.03] active:scale-[0.97]"
+      onClick={() => signIn("google")}
+    >
       Continue with Google
+      <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
     </Button>
   );
 };

--- a/src/app/components/layout/homePage/homePageLoggedOut/joinUsButton.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/joinUsButton.tsx
@@ -1,9 +1,14 @@
-'use client'
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { signIn } from "next-auth/react";
 
 const JoinUsButton = () => {
-  return <Button onClick={() => signIn()}>Join Socials</Button>;
+  return (
+    <Button size="lg" className="px-6" onClick={() => signIn("google")}>
+      Continue with Google
+    </Button>
+  );
 };
 
 export default JoinUsButton;

--- a/src/app/components/layout/homePage/homePageLoggedOut/landingPreview.tsx
+++ b/src/app/components/layout/homePage/homePageLoggedOut/landingPreview.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+const previewLinks = ["Instagram", "GitHub", "LinkedIn"];
+
+export function LandingPreview() {
+  const [active, setActive] = useState<string | null>(null);
+
+  return (
+    <div className="rounded-2xl border bg-card p-5 shadow-sm transition-shadow duration-300 hover:shadow-md">
+      <div className="mb-4 text-center">
+        <p className="font-medium">Your name</p>
+        <p className="text-sm text-muted-foreground">@yourname</p>
+      </div>
+      <div className="space-y-2">
+        {previewLinks.map((name) => {
+          const isActive = active === name;
+          return (
+            <button
+              key={name}
+              type="button"
+              onClick={() => {
+                setActive(name);
+                window.setTimeout(() => setActive((current) => (current === name ? null : current)), 420);
+              }}
+              className={cn(
+                "group flex w-full items-center justify-between rounded-xl bg-muted/80 px-4 py-3 text-left text-sm transition-all duration-200",
+                "hover:-translate-y-px hover:bg-muted hover:shadow-sm active:translate-y-0",
+                isActive && "motion-safe:animate-press-pop ring-1 ring-foreground/15"
+              )}
+            >
+              <span>{name}</span>
+              <span className="text-muted-foreground transition-transform duration-200 group-hover:translate-x-1">Open →</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/layout/navbar/mobile/navbarMobile.tsx
+++ b/src/app/components/layout/navbar/mobile/navbarMobile.tsx
@@ -1,36 +1,25 @@
 "use client";
-import Link from "next/link";
-import logo from "@/app/assets/logo.webp";
-
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-
 import { Menu } from "lucide-react";
-import { SessionProvider } from "next-auth/react";
 import ProfileButton from "@/app/components/ui/profileButton/profileButton";
-import Image from "next/image";
+import { Wordmark } from "@/app/components/ui/brand/wordmark";
 
 export default function NavigationMobile() {
   return (
-    <nav className="flex justify-between items-center p-2 drop-shadow-2xl md:hidden h-full">
-      <Link href={"/"} className="text-white text-lg flex items-center gap-2">
-        <h1 className="text-lg font-bold">SOCIALS</h1>
-        <Image src={logo} height={40} width={40} alt="SOCIALS" className="rounded-full" />
-      </Link>{" "}
-      {/* Updated for visibility */}
+    <nav className="flex h-full items-center justify-between p-2 md:hidden">
+      <Wordmark />
       <Sheet>
         <SheetTrigger>
-          <Menu className="text-white" /> {/* Ensured the menu icon is visible */}
+          <Menu className="text-foreground" />
         </SheetTrigger>
-        <SheetContent className="bg-gray-900 text-white">
+        <SheetContent>
           <SheetHeader>
-            <SheetTitle className="text-white">All your socials in one place</SheetTitle>
+            <SheetTitle>socials</SheetTitle>
           </SheetHeader>
           <SheetDescription>
-            <SessionProvider>
-              <div className="flex flex-col items-center gap-4 mt-10">
-                <ProfileButton />
-              </div>
-            </SessionProvider>
+            <div className="mt-10 flex flex-col items-center gap-4">
+              <ProfileButton />
+            </div>
           </SheetDescription>
         </SheetContent>
       </Sheet>

--- a/src/app/components/layout/navbar/navbar.tsx
+++ b/src/app/components/layout/navbar/navbar.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
-import logo from "@/app/assets/logo.webp";
 import ProfileButton from "@components/ui/profileButton/profileButton";
 import { PublicPageLink } from "@/app/components/ui/publicPageLink/publicPageLink";
 import useAuth from "@/app/hooks/useAuth";
+import { Wordmark } from "@/app/components/ui/brand/wordmark";
 
 export default function Navigation() {
   const { session, status } = useAuth();
@@ -13,11 +12,8 @@ export default function Navigation() {
 
   return (
     <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
-      <nav className="mx-auto flex h-14 w-full max-w-2xl items-center justify-between px-4">
-        <Link href="/" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
-          <Image src={logo} height={28} width={28} alt="" className="rounded-full" />
-          Socials
-        </Link>
+      <nav className="mx-auto flex h-14 w-full max-w-3xl items-center justify-between px-4">
+        <Wordmark className="text-[15px]" />
         <div className="flex items-center gap-4 text-sm">
           {signedIn && (
             <div className="hidden items-center gap-4 text-muted-foreground sm:flex">

--- a/src/app/components/layout/navbar/navbar.tsx
+++ b/src/app/components/layout/navbar/navbar.tsx
@@ -1,20 +1,35 @@
 "use client";
-import { SessionProvider } from "next-auth/react";
-import ProfileButton from "@components/ui/profileButton/profileButton";
+
 import Link from "next/link";
 import Image from "next/image";
 import logo from "@/app/assets/logo.webp";
+import ProfileButton from "@components/ui/profileButton/profileButton";
+import { PublicPageLink } from "@/app/components/ui/publicPageLink/publicPageLink";
+import useAuth from "@/app/hooks/useAuth";
 
 export default function Navigation() {
+  const { session, status } = useAuth();
+  const signedIn = status === "authenticated" && Boolean(session?.user);
+
   return (
-    <nav className="flex justify-between items-center p-2 ">
-      <Link href={"/"} className="text-white text-lg flex items-center gap-2">
-        <h1 className="text-lg font-bold">SOCIALS</h1>
-        <Image src={logo} height={40} width={40} alt="SOCIALS" className="rounded-full" />
-      </Link>{" "}
-      <SessionProvider>
-        <ProfileButton />
-      </SessionProvider>
-    </nav>
+    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
+      <nav className="mx-auto flex h-14 w-full max-w-2xl items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+          <Image src={logo} height={28} width={28} alt="" className="rounded-full" />
+          Socials
+        </Link>
+        <div className="flex items-center gap-4 text-sm">
+          {signedIn && (
+            <div className="hidden items-center gap-4 text-muted-foreground sm:flex">
+              <Link href="/choose-socials" className="hover:text-foreground">
+                Add
+              </Link>
+              <PublicPageLink className="hover:text-foreground" />
+            </div>
+          )}
+          <ProfileButton />
+        </div>
+      </nav>
+    </header>
   );
 }

--- a/src/app/components/layout/pageShell.tsx
+++ b/src/app/components/layout/pageShell.tsx
@@ -7,10 +7,12 @@ export function PageShell({
 }: {
   children: React.ReactNode;
   className?: string;
-  width?: "default" | "narrow";
+  width?: "default" | "narrow" | "wide";
 }) {
+  const maxWidth = width === "narrow" ? "max-w-md" : width === "wide" ? "max-w-3xl" : "max-w-2xl";
+
   return (
-    <main className={cn("mx-auto w-full px-4 py-10 sm:py-14", width === "narrow" ? "max-w-md" : "max-w-2xl", className)}>
+    <main className={cn("mx-auto w-full px-4 py-10 sm:py-14", maxWidth, className)}>
       {children}
     </main>
   );

--- a/src/app/components/layout/pageShell.tsx
+++ b/src/app/components/layout/pageShell.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+
+export function PageShell({
+  children,
+  className,
+  width = "default"
+}: {
+  children: React.ReactNode;
+  className?: string;
+  width?: "default" | "narrow";
+}) {
+  return (
+    <main className={cn("mx-auto w-full px-4 py-10 sm:py-14", width === "narrow" ? "max-w-md" : "max-w-2xl", className)}>
+      {children}
+    </main>
+  );
+}

--- a/src/app/components/layout/profile/editProfile.tsx
+++ b/src/app/components/layout/profile/editProfile.tsx
@@ -1,87 +1,72 @@
+"use client";
+
 import useToast from "@/app/hooks/useToast";
 import { USER } from "@/app/models/user";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { updateUserInfo } from "@/serverApi/Users/users";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import { useState } from "react";
+import { PageShell } from "@/app/components/layout/pageShell";
 
-const EditableProfilePage = ({ userData }: { userData?: USER | null }) => {
+const EditableProfilePage = ({
+  userData,
+  onCancel,
+  onSaved
+}: {
+  userData?: USER | null;
+  onCancel: () => void;
+  onSaved: () => void;
+}) => {
   const router = useRouter();
   const { showToast } = useToast();
-  const [email, setEmail] = useState(userData?.email || "");
   const [name, setName] = useState(userData?.name || "");
   const [username, setUsername] = useState(userData?.userName || "");
 
-  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const response = await updateUserInfo({ email, name, userName: username });
+    const response = await updateUserInfo({
+      email: userData?.email || "",
+      name,
+      userName: username
+    });
     if (response.success) {
-      showToast("Profile updated successfully", "success");
+      showToast("Saved", "success");
       router.refresh();
+      onSaved();
     } else {
-      console.error(response);
-      showToast(response.data.message || "Failed to update profile", "error");
+      showToast(response.data?.message || "Could not update profile", "error");
     }
-    // Add your logic
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-      <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg p-8 max-w-md w-full">
-        {/* Profile Information */}
-        <div className="text-center mb-6">
-          <h1 className="text-3xl font-bold text-gray-800 dark:text-white">Edit Profile</h1>
+    <PageShell width="narrow">
+      <h1 className="text-2xl font-semibold tracking-tight">Edit profile</h1>
+      <p className="mt-1 mb-8 text-sm text-muted-foreground">Email stays the same.</p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" value={userData?.email || ""} disabled />
         </div>
-
-        {/* Editable Form */}
-        <div className="space-y-4">
-          {/* Email */}
-          <div className="flex flex-col">
-            <label className="text-gray-600 dark:text-gray-300 mb-2 font-semibold">Email</label>
-
-            <Input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="border border-gray-300 dark:border-gray-600 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
-            />
-          </div>
-
-          {/* Name */}
-          <div className="flex flex-col">
-            <label className="text-gray-600 dark:text-gray-300 mb-2 font-semibold">Name</label>
-
-            <Input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="border border-gray-300 dark:border-gray-600 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
-              placeholder="Enter your name"
-            />
-          </div>
-
-          {/* Username */}
-          <div className="flex flex-col">
-            <label className="text-gray-600 dark:text-gray-300 mb-2 font-semibold">Username</label>
-            <Input
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              className="border border-gray-300 dark:border-gray-600 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
-              placeholder="Enter your username"
-            />
-          </div>
-
-          {/* Save Button */}
-          <div className="text-center">
-            <Button onClick={handleSubmit} variant={"default"}>
-              Save Changes
-            </Button>
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Your name" />
         </div>
-      </div>
-    </div>
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="yourname" />
+        </div>
+        <div className="flex gap-2 pt-2">
+          <Button type="submit" className="flex-1">
+            Save
+          </Button>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </PageShell>
   );
 };
 

--- a/src/app/components/layout/profile/editProfile.tsx
+++ b/src/app/components/layout/profile/editProfile.tsx
@@ -4,7 +4,7 @@ import useToast from "@/app/hooks/useToast";
 import { USER } from "@/app/models/user";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Field, PrefixField } from "@/app/components/ui/form/field";
 import { updateUserInfo } from "@/serverApi/Users/users";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -23,14 +23,17 @@ const EditableProfilePage = ({
   const { showToast } = useToast();
   const [name, setName] = useState(userData?.name || "");
   const [username, setUsername] = useState(userData?.userName || "");
+  const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSaving(true);
     const response = await updateUserInfo({
       email: userData?.email || "",
-      name,
-      userName: username
+      name: name.trim(),
+      userName: username.replace(/^@/, "").trim()
     });
+    setSaving(false);
     if (response.success) {
       showToast("Saved", "success");
       router.refresh();
@@ -43,25 +46,31 @@ const EditableProfilePage = ({
   return (
     <PageShell width="narrow">
       <h1 className="text-2xl font-semibold tracking-tight">Edit profile</h1>
-      <p className="mt-1 mb-8 text-sm text-muted-foreground">Email stays the same.</p>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
+      <p className="mt-1 mb-8 text-sm text-muted-foreground">This name and username show on your public page.</p>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <Field id="email" label="Email" hint="Signed in with Google — this cannot change here.">
           <Input id="email" type="email" value={userData?.email || ""} disabled />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="name">Name</Label>
-          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Your name" />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="username">Username</Label>
-          <Input id="username" value={username} onChange={(e) => setUsername(e.target.value)} placeholder="yourname" />
-        </div>
+        </Field>
+        <Field id="name" label="Display name" hint="Shown at the top of your public page.">
+          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Jane Doe" autoComplete="name" />
+        </Field>
+        <Field id="username" label="Username" hint="Short handle for your page, without spaces.">
+          <PrefixField prefix="@" alwaysShowPrefix>
+            <Input
+              id="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="h-11 border-0 shadow-none focus-visible:ring-0"
+              placeholder="janedoe"
+              autoComplete="username"
+            />
+          </PrefixField>
+        </Field>
         <div className="flex gap-2 pt-2">
-          <Button type="submit" className="flex-1">
-            Save
+          <Button type="submit" className="h-11 flex-1" disabled={saving || !name.trim()}>
+            {saving ? "Saving…" : "Save"}
           </Button>
-          <Button type="button" variant="outline" onClick={onCancel}>
+          <Button type="button" variant="outline" className="h-11" onClick={onCancel}>
             Cancel
           </Button>
         </div>

--- a/src/app/components/layout/profile/profile.tsx
+++ b/src/app/components/layout/profile/profile.tsx
@@ -73,7 +73,7 @@ const Profile = () => {
     <PageShell width="narrow">
       <h1 className="text-2xl font-semibold tracking-tight">{userData?.name || "Profile"}</h1>
       <p className="mt-1 mb-8 text-sm text-muted-foreground">{userData?.userName ? `@${userData.userName}` : "Add a username so your page is easier to share."}</p>
-      <div className="divide-y rounded-2xl border">
+      <div className="divide-y overflow-hidden rounded-2xl border bg-card shadow-sm">
         {rows.map((row) => (
           <div key={row.label} className="flex items-center justify-between px-4 py-3 text-sm">
             <span className="text-muted-foreground">{row.label}</span>

--- a/src/app/components/layout/profile/profile.tsx
+++ b/src/app/components/layout/profile/profile.tsx
@@ -1,76 +1,91 @@
 "use client";
+
 import useAuth from "@/app/hooks/useAuth";
 import { getUser } from "@/serverApi/Users/users";
-import React from "react";
+import { useEffect, useState } from "react";
 import EditableProfilePage from "./editProfile";
 import { Button } from "@/components/ui/button";
 import { USER } from "@/app/models/user";
 import AuthButton from "../../ui/authButton/authButton";
+import { PageShell } from "@/app/components/layout/pageShell";
 
 const Profile = () => {
-  const [userData, setUserData] = React.useState<USER | null>();
-  const [isEditing, setIsEditing] = React.useState(false);
+  const [userData, setUserData] = useState<USER | null>();
+  const [isEditing, setIsEditing] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
   const { status, session } = useAuth();
-  // const [currentSession, setCurrentSession] = React.useState(session);
+  const email = session?.user?.email || "";
 
-  const fetchUserData = async () => {
-    console.log("SESSION IS ", session);
-    const response = await getUser({ email: session?.user?.email || "" });
-    if (response.success) {
-      setUserData(response.data || null);
-    } else {
-      console.error(response);
-      setUserData(null);
+  useEffect(() => {
+    if (!email) {
+      return;
     }
-  };
-  React.useEffect(() => {
-    fetchUserData();
-  }, [session, status]);
-  if (status === "loading") return <div>Loading...</div>;
-  if (session?.user) {
+
+    let cancelled = false;
+    getUser({ email }).then((response) => {
+      if (!cancelled) {
+        setUserData(response.success ? response.data || null : null);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [email, reloadToken]);
+
+  if (status === "loading") {
     return (
-      <>
-        {!isEditing && (
-          <div className="min-h-screen flex items-center justify-center flex-col bg-gray-50 dark:bg-gray-900">
-            <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg p-8 max-w-md w-full">
-              {/* Profile Information */}
-              <div className="text-center mb-6">
-                <h1 className="text-3xl font-bold text-gray-800 dark:text-white">{userData?.name}</h1>
-                <p className="text-sm text-gray-500 dark:text-gray-400">@{userData?.userName}</p>
-              </div>
-
-              {/* Details */}
-              <div className="space-y-4">
-                {/* Email */}
-                <div className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 p-4 rounded-lg">
-                  <span className="text-gray-600 dark:text-gray-300">Email</span>
-                  <span className="text-gray-800 dark:text-white">{userData?.email}</span>
-                </div>
-
-                {/* Name */}
-                <div className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 p-4 rounded-lg">
-                  <span className="text-gray-600 dark:text-gray-300">Name</span>
-                  <span className="text-gray-800 dark:text-white">{userData?.name}</span>
-                </div>
-
-                {/* Username */}
-                <div className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 p-4 rounded-lg">
-                  <span className="text-gray-600 dark:text-gray-300">Username</span>
-                  <span className="text-gray-800 dark:text-white">@{userData?.userName}</span>
-                </div>
-              </div>
-            </div>
-            <Button onClick={() => setIsEditing(!isEditing)} className="mt-4">
-              {isEditing ? "Cancel" : "Edit Profile"}
-            </Button>
-          </div>
-        )}
-        {isEditing && <EditableProfilePage userData={userData} />}
-      </>
+      <PageShell width="narrow">
+        <div className="h-40 animate-pulse rounded-2xl bg-muted" />
+      </PageShell>
     );
-  } else {
-    return <AuthButton />;
   }
+
+  if (!session?.user) {
+    return (
+      <PageShell width="narrow" className="text-center">
+        <p className="mb-4 text-muted-foreground">Sign in to view your profile.</p>
+        <AuthButton />
+      </PageShell>
+    );
+  }
+
+  if (isEditing) {
+    return (
+      <EditableProfilePage
+        userData={userData}
+        onCancel={() => setIsEditing(false)}
+        onSaved={() => {
+          setIsEditing(false);
+          setReloadToken((token) => token + 1);
+        }}
+      />
+    );
+  }
+
+  const rows = [
+    { label: "Email", value: userData?.email },
+    { label: "Name", value: userData?.name },
+    { label: "Username", value: userData?.userName ? `@${userData.userName}` : "Not set" }
+  ];
+
+  return (
+    <PageShell width="narrow">
+      <h1 className="text-2xl font-semibold tracking-tight">{userData?.name || "Profile"}</h1>
+      <p className="mt-1 mb-8 text-sm text-muted-foreground">{userData?.userName ? `@${userData.userName}` : "Add a username so your page is easier to share."}</p>
+      <div className="divide-y rounded-2xl border">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-center justify-between px-4 py-3 text-sm">
+            <span className="text-muted-foreground">{row.label}</span>
+            <span>{row.value || "—"}</span>
+          </div>
+        ))}
+      </div>
+      <Button className="mt-6 w-full" onClick={() => setIsEditing(true)}>
+        Edit profile
+      </Button>
+    </PageShell>
+  );
 };
 
 export default Profile;

--- a/src/app/components/layout/providers.tsx
+++ b/src/app/components/layout/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/app/components/ui/authButton/authButton.tsx
+++ b/src/app/components/ui/authButton/authButton.tsx
@@ -1,19 +1,26 @@
 "use client";
+
 import { Button } from "@/components/ui/button";
-import { signIn, signOut, useSession } from "next-auth/react";
+import { signIn, signOut } from "next-auth/react";
 
 type AuthButtonProps = {
   mode?: "signin" | "signout";
 };
+
 const AuthButton = ({ mode = "signin" }: AuthButtonProps) => {
-  const session = useSession();
-  console.log("SESSION", session);
-  const handleLogin = async () => {
-    console.log("LOGIN HAPPENS");
-    await signIn("google");
-    localStorage.setItem("user", JSON.stringify(session.data?.user));
-  };
-  return <>{mode === "signin" ? <Button onClick={handleLogin}>Join Socials</Button> : <Button onClick={() => signOut()}>Signout</Button>}</>;
+  if (mode === "signout") {
+    return (
+      <Button variant="ghost" size="sm" onClick={() => signOut()}>
+        Sign out
+      </Button>
+    );
+  }
+
+  return (
+    <Button size="sm" onClick={() => signIn("google")}>
+      Sign in
+    </Button>
+  );
 };
 
 export default AuthButton;

--- a/src/app/components/ui/brand/wordmark.tsx
+++ b/src/app/components/ui/brand/wordmark.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export function Wordmark({ className, href = "/" }: { className?: string; href?: string | null }) {
+  const mark = (
+    <span className={cn("font-semibold tracking-tight", className)}>
+      socials
+    </span>
+  );
+
+  if (!href) {
+    return mark;
+  }
+
+  return (
+    <Link href={href} className="inline-flex items-baseline text-foreground">
+      {mark}
+    </Link>
+  );
+}

--- a/src/app/components/ui/brand/wordmark.tsx
+++ b/src/app/components/ui/brand/wordmark.tsx
@@ -13,7 +13,7 @@ export function Wordmark({ className, href = "/" }: { className?: string; href?:
   }
 
   return (
-    <Link href={href} className="inline-flex items-baseline text-foreground">
+    <Link href={href} className="inline-flex items-baseline text-foreground transition-opacity hover:opacity-70">
       {mark}
     </Link>
   );

--- a/src/app/components/ui/copyToClipBoard/copyToClipBoard.tsx
+++ b/src/app/components/ui/copyToClipBoard/copyToClipBoard.tsx
@@ -1,16 +1,19 @@
 "use client";
+
 import useToast from "@/app/hooks/useToast";
 import { Button } from "@/components/ui/button";
-import React from "react";
 
-const CopyToClipBoard = ({ text = "" }) => {
-  console.log("copy text",text);
+const CopyToClipBoard = ({ text = "", label = "Copy" }: { text?: string; label?: string }) => {
   const { showToast } = useToast();
   const handleCopy = () => {
     navigator.clipboard.writeText(text);
-    showToast("Copied to clipboard", "success");
+    showToast("Copied", "success");
   };
-  return <Button onClick={handleCopy}>Copy</Button>;
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy}>
+      {label}
+    </Button>
+  );
 };
 
 export default CopyToClipBoard;

--- a/src/app/components/ui/form/field.tsx
+++ b/src/app/components/ui/form/field.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+export function Field({
+  id,
+  label,
+  hint,
+  error,
+  children
+}: {
+  id: string;
+  label: string;
+  hint?: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id} className="text-[13px] font-medium text-foreground">
+        {label}
+      </Label>
+      {children}
+      {error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : hint ? (
+        <p className="text-sm text-muted-foreground">{hint}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function PrefixField({
+  prefix,
+  className,
+  alwaysShowPrefix = false,
+  children
+}: {
+  prefix: string;
+  className?: string;
+  alwaysShowPrefix?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-11 items-stretch overflow-hidden rounded-lg border border-input bg-card focus-within:border-foreground focus-within:ring-2 focus-within:ring-ring/15",
+        className
+      )}
+    >
+      <span
+        className={cn(
+          "items-center truncate border-r bg-muted/80 px-3 text-sm text-muted-foreground",
+          alwaysShowPrefix ? "flex" : "hidden max-w-[48%] sm:flex"
+        )}
+      >
+        {prefix}
+      </span>
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/ui/profileButton/profileButton.tsx
+++ b/src/app/components/ui/profileButton/profileButton.tsx
@@ -1,54 +1,60 @@
 "use client";
+
 import Link from "next/link";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { signOut } from "next-auth/react";
-
 import { LogOut, Plus, User } from "lucide-react";
-
 import useAuth from "@/app/hooks/useAuth";
 import AuthButton from "@components/ui/authButton/authButton";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-
-const PROFILE_LINKS = [
-  { title: "Profile", href: "/profile", icon: <User size={20} /> },
-  // { title: "Settings", href: "/settings", icon: <Settings size={20} /> }
-  { title: "Create Socials", href: "/choose-socials", icon: <Plus size={20} /> }
-  
-];
+import { PublicPageMenuItem } from "@/app/components/ui/publicPageLink/publicPageLink";
 
 const ProfileButton = () => {
   const { session, status } = useAuth();
-  if (status === "loading") return <div>Loading...</div>;
-  if (session?.user) {
-    return (
-      <div className="profile-container">
-        <DropdownMenu>
-          <DropdownMenuTrigger>
-            <Avatar>
-              <AvatarImage src={session.user.image || ""} />
-              <AvatarFallback>{session.user.name?.split(" ")[0][0] + (session.user.name?.split(" ")[1][0] || "")}</AvatarFallback>
-            </Avatar>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuLabel>My Account</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {PROFILE_LINKS.map((link, index) => (
-              <DropdownMenuItem key={index} className="profile-list-none p-2 cursor-pointer transition-colors duration-300 flex justify-between items-center hover:bg-gray-300">
-                <Link href={link.href}>{link.title}</Link>
-                {link.icon}
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuItem className="profile-list-none p-2 cursor-pointer transition-colors duration-300 flex justify-between items-center hover:bg-gray-300" onClick={() => signOut()}>
-              Sign Out
-              <LogOut size={20} />
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    );
-  } else {
+
+  if (status === "loading") {
+    return <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />;
+  }
+
+  if (!session?.user) {
     return <AuthButton mode="signin" />;
   }
+
+  const names = session.user.name?.split(" ") ?? [];
+  const initials = `${names[0]?.[0] ?? ""}${names[1]?.[0] ?? ""}` || "U";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="rounded-full outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring">
+        <Avatar className="h-8 w-8">
+          <AvatarImage src={session.user.image || ""} alt="" />
+          <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+        </Avatar>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuLabel className="truncate font-normal text-muted-foreground">{session.user.email}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/profile" className="flex cursor-pointer items-center justify-between">
+            Profile
+            <User size={16} />
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href="/choose-socials" className="flex cursor-pointer items-center justify-between">
+            Add a social
+            <Plus size={16} />
+          </Link>
+        </DropdownMenuItem>
+        <PublicPageMenuItem />
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="flex cursor-pointer items-center justify-between" onClick={() => signOut()}>
+          Sign out
+          <LogOut size={16} />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 };
 
 export default ProfileButton;

--- a/src/app/components/ui/publicPageLink/publicPageLink.tsx
+++ b/src/app/components/ui/publicPageLink/publicPageLink.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { ExternalLink } from "lucide-react";
+
+export function PublicPageLink({
+  className,
+  children
+}: {
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const [userId, setUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem("dbUserData") || "{}");
+      setUserId(stored?._id || null);
+    } catch {
+      setUserId(null);
+    }
+  }, []);
+
+  if (!userId) {
+    return null;
+  }
+
+  return (
+    <Link href={`/${userId}`} className={className}>
+      {children ?? "My page"}
+    </Link>
+  );
+}
+
+export function PublicPageMenuItem() {
+  const [userId, setUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem("dbUserData") || "{}");
+      setUserId(stored?._id || null);
+    } catch {
+      setUserId(null);
+    }
+  }, []);
+
+  if (!userId) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuItem asChild>
+      <Link href={`/${userId}`} className="flex cursor-pointer items-center justify-between">
+        My page
+        <ExternalLink size={16} />
+      </Link>
+    </DropdownMenuItem>
+  );
+}

--- a/src/app/components/ui/shareButton/shareButton.tsx
+++ b/src/app/components/ui/shareButton/shareButton.tsx
@@ -1,50 +1,53 @@
 "use client";
+
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-
 import { FacebookShareButton, FacebookIcon, PinterestShareButton, PinterestIcon, RedditShareButton, RedditIcon, WhatsappShareButton, WhatsappIcon, LinkedinShareButton, LinkedinIcon } from "next-share";
 import CopyToClipBoard from "../copyToClipBoard/copyToClipBoard";
-const getShareUrl = () => {
-  if (JSON.parse(localStorage.getItem("dbUserData") || "{}")?._id === undefined) {
-    return window.location.href;
-  }
-  return "https://socials-blond-ten.vercel.app/" + JSON.parse(localStorage.getItem("dbUserData") || "{}")?._id;
-};
-const ShareButton = () => {
-  const shareUrl = getShareUrl();
-  return (
-    <div>
-      <Dialog>
-        <DialogTrigger asChild>
-          <Button variant="outline">Share Profile</Button>
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Share Your Profile</DialogTitle>
-            <DialogDescription>Connect with your friends and family by sharing your profile</DialogDescription>
-          </DialogHeader>
-          <div className="flex gap-2 flex-wrap items-center justify-center">
-            <FacebookShareButton url={shareUrl}>
-              <FacebookIcon size={32} round />
-            </FacebookShareButton>
-            <PinterestShareButton media="" url={shareUrl}>
-              <PinterestIcon size={32} round />
-            </PinterestShareButton>
-            <RedditShareButton url={shareUrl}>
-              <RedditIcon size={32} round />
-            </RedditShareButton>
-            <WhatsappShareButton url={shareUrl}>
-              <WhatsappIcon size={32} round />
-            </WhatsappShareButton>
-            <LinkedinShareButton url={shareUrl}>
-              <LinkedinIcon size={32} round />
-            </LinkedinShareButton>
-          </div>
+import { useEffect, useState } from "react";
 
-          <CopyToClipBoard text={shareUrl} />
-        </DialogContent>
-      </Dialog>{" "}
-    </div>
+const ShareButton = () => {
+  const [shareUrl, setShareUrl] = useState("");
+
+  useEffect(() => {
+    try {
+      const id = JSON.parse(localStorage.getItem("dbUserData") || "{}")?._id;
+      setShareUrl(id ? `${window.location.origin}/${id}` : window.location.href);
+    } catch {
+      setShareUrl(window.location.href);
+    }
+  }, []);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Share</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Share this page</DialogTitle>
+          <DialogDescription>Copy the link or send it from an app.</DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-center gap-3">
+          <FacebookShareButton url={shareUrl}>
+            <FacebookIcon size={32} round />
+          </FacebookShareButton>
+          <PinterestShareButton media="" url={shareUrl}>
+            <PinterestIcon size={32} round />
+          </PinterestShareButton>
+          <RedditShareButton url={shareUrl}>
+            <RedditIcon size={32} round />
+          </RedditShareButton>
+          <WhatsappShareButton url={shareUrl}>
+            <WhatsappIcon size={32} round />
+          </WhatsappShareButton>
+          <LinkedinShareButton url={shareUrl}>
+            <LinkedinIcon size={32} round />
+          </LinkedinShareButton>
+        </div>
+        <CopyToClipBoard text={shareUrl} label="Copy link" />
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/app/components/ui/socialCard/socialCard.tsx
+++ b/src/app/components/ui/socialCard/socialCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 
 type SocialCardProps = {
   _id: string;
@@ -11,11 +12,20 @@ const SocialCard = ({ title, socialLogo, _id }: SocialCardProps) => {
   return (
     <Link
       href={`/new/${_id}`}
-      className="flex items-center gap-3 rounded-2xl border bg-card px-4 py-3 transition-colors hover:bg-muted"
+      className="group flex items-center gap-3 rounded-2xl border bg-card px-4 py-3.5 shadow-sm transition-all hover:-translate-y-px hover:shadow-md"
     >
-      {socialLogo && <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${socialLogo}`} alt="" height={36} width={36} className="rounded-md" />}
+      <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted">
+        {socialLogo ? (
+          <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${socialLogo}`} alt="" height={28} width={28} className="rounded-md" />
+        ) : (
+          <span className="text-sm font-medium">{title[0]}</span>
+        )}
+      </div>
       <span className="flex-1 font-medium">{title}</span>
-      <span className="text-sm text-muted-foreground">Add</span>
+      <span className="flex items-center gap-0.5 text-sm text-muted-foreground">
+        Add
+        <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+      </span>
     </Link>
   );
 };

--- a/src/app/components/ui/socialCard/socialCard.tsx
+++ b/src/app/components/ui/socialCard/socialCard.tsx
@@ -1,35 +1,22 @@
-import React from "react";
 import Image from "next/image";
-import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-interface SocialCardProps {
+type SocialCardProps = {
   _id: string;
   title: string;
   socialLogo: string;
-}
+};
 
-const SocialCard: React.FC<SocialCardProps> = ({ title, socialLogo,_id }) => {
+const SocialCard = ({ title, socialLogo, _id }: SocialCardProps) => {
   return (
-    <div className="bg-gray-100 dark:bg-gray-700 rounded-lg shadow-md p-4 transition-transform duration-300 transform hover:scale-105 hover:shadow-xl">
-      <div className="flex items-center">
-        {/* Social Logo */}
-        <div className="w-12 h-w-12 relative">{socialLogo && <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${socialLogo}`} alt={title} height={40} width={40} objectFit="cover" className="rounded-md" />}</div>
-
-        {/* Social Info */}
-        <div className="ml-4 flex-grow">
-          <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
-        </div>
-
-        {/* Create Button */}
-        <div>
-          <Button className="bg-blue-600 dark:bg-blue-500 text-white py-1 px-3 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors">
-
-            <Link href={`/new/${_id}`}>Create</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
+    <Link
+      href={`/new/${_id}`}
+      className="flex items-center gap-3 rounded-2xl border bg-card px-4 py-3 transition-colors hover:bg-muted"
+    >
+      {socialLogo && <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${socialLogo}`} alt="" height={36} width={36} className="rounded-md" />}
+      <span className="flex-1 font-medium">{title}</span>
+      <span className="text-sm text-muted-foreground">Add</span>
+    </Link>
   );
 };
 

--- a/src/app/components/ui/socialForm/editSocialForm.tsx
+++ b/src/app/components/ui/socialForm/editSocialForm.tsx
@@ -1,10 +1,11 @@
 "use client";
+
 import { USER_SOCIAL } from "@/app/models/socials";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Field, PrefixField } from "@/app/components/ui/form/field";
 
 type EditSocialFormProps = {
   handle: USER_SOCIAL;
@@ -13,23 +14,30 @@ type EditSocialFormProps = {
 
 const EditSocialForm = ({ handle, handleSave }: EditSocialFormProps) => {
   const [newHandle, setHandle] = useState(handle.handle);
+  const prefix = handle.platform.socialBaseUrl || "";
+  const cleaned = newHandle.replace(/^@/, "").trim();
 
   return (
-    <>
-      <div className="grid gap-4 py-4">
-        <div className="grid grid-cols-4 items-center gap-4">
-          <Label htmlFor="handle" className="text-right">
-            Handle
-          </Label>
-          <Input id="handle" name="handle" value={newHandle} onChange={(e) => setHandle(e.target.value)} className="col-span-3" />
-        </div>
-      </div>
+    <div className="space-y-6">
+      <Field id="handle" label={`${handle.platform.title} handle`} hint={cleaned ? `${prefix}${cleaned}` : "Username only, without @."}>
+        <PrefixField prefix={prefix || `${handle.platform.title.toLowerCase()}/`}>
+          <Input
+            id="handle"
+            name="handle"
+            value={newHandle}
+            onChange={(e) => setHandle(e.target.value)}
+            className="h-11 border-0 shadow-none focus-visible:ring-0"
+            placeholder="username"
+            autoComplete="off"
+          />
+        </PrefixField>
+      </Field>
       <DialogFooter>
-        <Button onClick={() => handleSave(newHandle)} type="submit">
-          Save changes
+        <Button onClick={() => handleSave(cleaned)} type="button" disabled={!cleaned} className="h-11 w-full sm:w-auto">
+          Save handle
         </Button>
       </DialogFooter>
-    </>
+    </div>
   );
 };
 

--- a/src/app/components/ui/socialForm/socialForm.tsx
+++ b/src/app/components/ui/socialForm/socialForm.tsx
@@ -5,21 +5,27 @@ import { Social } from "@/app/models/socials";
 import { addUserHandle } from "@/serverApi/Users/users";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Field, PrefixField } from "@/app/components/ui/form/field";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 const SocialForm = ({ socialData }: { socialData: Social }) => {
   const router = useRouter();
   const { showToast } = useToast();
   const [handle, setHandle] = useState("");
   const [saving, setSaving] = useState(false);
-  const testLink = `${socialData.socialBaseUrl}${handle}`;
+
+  const prefix = socialData.socialBaseUrl || "";
+  const cleanedHandle = handle.replace(/^@/, "").trim();
+  const testLink = useMemo(() => `${prefix}${cleanedHandle}`, [prefix, cleanedHandle]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (!cleanedHandle) {
+      return;
+    }
     setSaving(true);
-    const response = await addUserHandle({ formData: { handle }, socialData });
+    const response = await addUserHandle({ formData: { handle: cleanedHandle }, socialData });
     setSaving(false);
     if (response.success) {
       showToast("Added", "success");
@@ -32,35 +38,35 @@ const SocialForm = ({ socialData }: { socialData: Social }) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="space-y-2">
-        <Label htmlFor="handle">Your {socialData.title} handle</Label>
-        <div className="flex overflow-hidden rounded-md border focus-within:ring-1 focus-within:ring-ring">
-          {socialData.socialBaseUrl && (
-            <span className="hidden max-w-[55%] truncate bg-muted px-3 py-2 text-sm text-muted-foreground sm:inline">
-              {socialData.socialBaseUrl}
-            </span>
-          )}
+      <Field
+        id="handle"
+        label={`${socialData.title} handle`}
+        hint={cleanedHandle ? `Opens ${testLink}` : "Use the username only — we attach the platform URL."}
+      >
+        <PrefixField prefix={prefix || `${socialData.title.toLowerCase()}/`}>
           <Input
             id="handle"
             name="handle"
             value={handle}
             onChange={(e) => setHandle(e.target.value)}
-            className="border-0 shadow-none focus-visible:ring-0"
+            className="h-11 border-0 shadow-none focus-visible:ring-0"
             placeholder="username"
+            autoComplete="off"
+            autoFocus
             required
           />
-        </div>
-        {handle && (
-          <a href={testLink} target="_blank" rel="noopener noreferrer" className="block truncate text-sm text-muted-foreground hover:text-foreground">
-            {testLink}
-          </a>
-        )}
-      </div>
+        </PrefixField>
+      </Field>
+      {cleanedHandle && (
+        <a href={testLink} target="_blank" rel="noopener noreferrer" className="block text-sm text-muted-foreground hover:text-foreground">
+          Preview link
+        </a>
+      )}
       <div className="flex gap-2">
-        <Button type="submit" disabled={saving || !handle.trim()} className="flex-1">
+        <Button type="submit" disabled={saving || !cleanedHandle} className="h-11 flex-1">
           {saving ? "Saving…" : "Add to my page"}
         </Button>
-        <Button type="button" variant="outline" onClick={() => router.push("/choose-socials")}>
+        <Button type="button" variant="outline" className="h-11" onClick={() => router.push("/choose-socials")}>
           Back
         </Button>
       </div>

--- a/src/app/components/ui/socialForm/socialForm.tsx
+++ b/src/app/components/ui/socialForm/socialForm.tsx
@@ -1,125 +1,69 @@
 "use client";
+
 import useToast from "@/app/hooks/useToast";
 import { Social } from "@/app/models/socials";
 import { addUserHandle } from "@/serverApi/Users/users";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import { useState } from "react";
 
 const SocialForm = ({ socialData }: { socialData: Social }) => {
   const router = useRouter();
   const { showToast } = useToast();
-  const [formData, setFormData] = useState({
-    handle: "",
-    redirectUrl: ""
-  });
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
-  };
+  const [handle, setHandle] = useState("");
+  const [saving, setSaving] = useState(false);
+  const testLink = `${socialData.socialBaseUrl}${handle}`;
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const response = await addUserHandle({ formData, socialData });
+    setSaving(true);
+    const response = await addUserHandle({ formData: { handle }, socialData });
+    setSaving(false);
     if (response.success) {
-      // alert("Handle added successfully");
-      showToast("Handle added successfully", "success");
+      showToast("Added", "success");
       router.push("/");
       router.refresh();
     } else {
-      console.error(response);
-      // alert("Failed to add handle");
-      showToast(response.data.message || "Failed to add handle", "error");
+      showToast(response.data?.message || "Could not add handle", "error");
     }
   };
 
-  // Generate test link URL dynamically
-  const testLink = `${socialData.socialBaseUrl}${formData.handle}`;
-
-  // const testRedirectLink = formData.redirectUrl;
-
   return (
-    <form onSubmit={handleSubmit} className="max-w-md mx-auto p-0 lg:p-6 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-lg rounded-t-none">
-      {/* Pre-field title */}
-      <div className="mb-6">
-        <label htmlFor="preFieldTitle" className="block text-lg font-semibold text-gray-700 dark:text-gray-200 mb-2">
-          Title
-        </label>
-        <input
-          readOnly
-          type="text"
-          id="preFieldTitle"
-          name="preFieldTitle"
-          value={socialData.title}
-          onChange={handleChange}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-black"
-          placeholder="Enter pre-field title"
-        />
-      </div>
-
-      {/* Handle input (with test link) */}
-      <div className="mb-6">
-        <label className="block text-lg font-semibold text-gray-700 dark:text-gray-200 mb-2">Your {socialData.title} Handle</label>
-        <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg">
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="handle">Your {socialData.title} handle</Label>
+        <div className="flex overflow-hidden rounded-md border focus-within:ring-1 focus-within:ring-ring">
           {socialData.socialBaseUrl && (
-            <>
-              <input type="text" value={socialData.socialBaseUrl.substring(0, socialData.socialBaseUrl.length - 1)} className="w-full px-3 py-2 pr-1 border-none bg-transparent text-black dark:text-white" readOnly />
-              <span className="px-3 h-full text-gray-700 dark:text-gray-300">/</span>
-            </>
+            <span className="hidden max-w-[55%] truncate bg-muted px-3 py-2 text-sm text-muted-foreground sm:inline">
+              {socialData.socialBaseUrl}
+            </span>
           )}
-          <input
-            type="text"
+          <Input
+            id="handle"
             name="handle"
-            value={formData.handle}
-            onChange={handleChange}
-            className="w-full px-3 py-2 border-none rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-black rounded-l-none"
-            placeholder="Enter handle"
+            value={handle}
+            onChange={(e) => setHandle(e.target.value)}
+            className="border-0 shadow-none focus-visible:ring-0"
+            placeholder="username"
+            required
           />
         </div>
-        {/* Test Link */}
-        {formData.handle && (
-          <div className="mt-2">
-            <a href={testLink} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">
-              Your Link: {testLink}
-            </a>
-          </div>
+        {handle && (
+          <a href={testLink} target="_blank" rel="noopener noreferrer" className="block truncate text-sm text-muted-foreground hover:text-foreground">
+            {testLink}
+          </a>
         )}
       </div>
-      {/* <div className="flex items-center my-4">
-        <hr className="flex-grow border-t border-gray-300 dark:border-gray-600" />
-        <p className="mx-4 text-gray-700 dark:text-gray-300 font-semibold">Or use your own URL</p>
-        <hr className="flex-grow border-t border-gray-300 dark:border-gray-600" />
-      </div> */}
-
-      {/* Redirect URL field */}
-      {/* <div className="mb-6">
-        <label htmlFor="redirectUrl" className="block text-lg font-semibold text-gray-700 dark:text-gray-200 mb-2">
-          Redirect URL
-        </label>
-        <input
-          type="url"
-          id="redirectUrl"
-          name="redirectUrl"
-          value={formData.redirectUrl}
-          onChange={handleChange}
-          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-black"
-          placeholder="Enter redirect URL"
-        />
-        {formData.redirectUrl && (
-          <div className="mt-2">
-            <a href={testRedirectLink} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">
-              Your Link: {testRedirectLink}
-            </a>
-          </div>
-        )}
-      </div> */}
-
-      {/* Submit Button */}
-      <button type="submit" className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors">
-        Submit
-      </button>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={saving || !handle.trim()} className="flex-1">
+          {saving ? "Saving…" : "Add to my page"}
+        </Button>
+        <Button type="button" variant="outline" onClick={() => router.push("/choose-socials")}>
+          Back
+        </Button>
+      </div>
     </form>
   );
 };

--- a/src/app/components/ui/socialsList/socialsList.tsx
+++ b/src/app/components/ui/socialsList/socialsList.tsx
@@ -2,6 +2,8 @@ import { Social } from "@/app/models/socials";
 import { dbConnect } from "@/lib/db/mongoose";
 import { getDefaultSocials } from "@/lib/services/socials";
 import SocialCard from "../socialCard/socialCard";
+import { PageShell } from "@/app/components/layout/pageShell";
+import Link from "next/link";
 
 const SocialsList = async () => {
   await dbConnect();
@@ -9,24 +11,26 @@ const SocialsList = async () => {
   const data = Array.isArray(socials.body) ? (socials.body as Social[]) : [];
 
   return (
-    <div className="p-6">
-      {/* Section for default options */}
-      <section className="mb-12">
-        <h1 className="text-3xl font-bold text-center mb-8 text-gray-900 dark:text-gray-100">Choose from the default options</h1>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <PageShell>
+      <p className="mb-2 text-sm text-muted-foreground">
+        <Link href="/" className="hover:text-foreground">
+          Home
+        </Link>
+        <span className="mx-2">/</span>
+        Add
+      </p>
+      <h1 className="text-2xl font-semibold tracking-tight">Choose a platform</h1>
+      <p className="mt-1 mb-8 text-sm text-muted-foreground">Pick one, then add your handle.</p>
+      {data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No platforms found. Check the database connection.</p>
+      ) : (
+        <div className="space-y-2">
           {data.map((social: Social) => (
             <SocialCard key={social._id} {...social} />
           ))}
         </div>
-      </section>
-
-      {/* Section for creating your own social */}
-      {/* <section className="text-center">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">Or create your own</h1>
-        <button className="bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors">Create New Social</button>
-      </section> */}
-    </div>
+      )}
+    </PageShell>
   );
 };
 

--- a/src/app/components/ui/socialsList/socialsList.tsx
+++ b/src/app/components/ui/socialsList/socialsList.tsx
@@ -24,7 +24,7 @@ const SocialsList = async () => {
       {data.length === 0 ? (
         <p className="text-sm text-muted-foreground">No platforms found. Check the database connection.</p>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-3">
           {data.map((social: Social) => (
             <SocialCard key={social._id} {...social} />
           ))}

--- a/src/app/components/ui/userSocialCard/deleteUserCard.tsx
+++ b/src/app/components/ui/userSocialCard/deleteUserCard.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import useToast from "@/app/hooks/useToast";
 import { USER_SOCIAL } from "@/app/models/socials";
 import { Button } from "@/components/ui/button";
@@ -9,44 +10,45 @@ import React from "react";
 
 const DeleteUserCard = ({ handle }: { handle: USER_SOCIAL }) => {
   const { showToast } = useToast();
-
-  const [isEditing, setIsEditing] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
   const router = useRouter();
+
   const handleDelete = async () => {
-    const response = await deleteUserHandle({ email: JSON.parse(localStorage.getItem("dbUserData") || "{}")?.email || "", platformId: handle._id });
+    const response = await deleteUserHandle({
+      email: JSON.parse(localStorage.getItem("dbUserData") || "{}")?.email || "",
+      platformId: handle._id
+    });
     if (response.success) {
-      showToast("Handle updated successfully", "success");
+      showToast("Removed", "success");
     } else {
-      showToast(response.message || "Failed to update handle", "error");
+      showToast(response.message || "Could not delete", "error");
     }
-    setIsEditing(false);
+    setOpen(false);
     router.refresh();
   };
+
   return (
-    <>
-      <Dialog open={isEditing}>
-        <DialogTrigger asChild>
-          <Button onClick={() => setIsEditing(true)} variant="destructive">
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-destructive">
+          Delete
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Remove {handle.platform.title}?</DialogTitle>
+          <DialogDescription>This also removes it from your public page.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={() => setOpen(false)} variant="outline">
+            Cancel
+          </Button>
+          <Button onClick={handleDelete} variant="destructive">
             Delete
           </Button>
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Delete {handle.platform.title}</DialogTitle>
-            <DialogDescription>Are you sure you want to delete this handle?</DialogDescription>
-          </DialogHeader>
-          <p>This will update your public page too.</p>
-          <DialogFooter>
-            <Button onClick={handleDelete} variant={"destructive"}>
-              Delete
-            </Button>
-            <Button onClick={() => setIsEditing(false)} variant={"outline"} type="submit">
-              Cancel
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/app/components/ui/userSocialCard/editUserCard.tsx
+++ b/src/app/components/ui/userSocialCard/editUserCard.tsx
@@ -1,10 +1,10 @@
 "use client";
+
 import { USER_SOCIAL } from "@/app/models/socials";
 import { useState } from "react";
 import EditSocialForm from "../socialForm/editSocialForm";
 import { updateUserHandle } from "@/serverApi/Users/users";
 import { useRouter } from "next/navigation";
-
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import useToast from "@/app/hooks/useToast";
@@ -14,41 +14,42 @@ const EditUserCard = ({ handle }: { handle: USER_SOCIAL }) => {
   const [isEditing, setIsEditing] = useState(false);
   const router = useRouter();
   const handleSave = async (newHandle: string) => {
-    const response = await updateUserHandle({ email: JSON.parse(localStorage.getItem("dbUserData") || "{}")?.email || "", platformId: handle._id, handle: newHandle });
+    const response = await updateUserHandle({
+      email: JSON.parse(localStorage.getItem("dbUserData") || "{}")?.email || "",
+      platformId: handle._id,
+      handle: newHandle
+    });
 
     if (response.success) {
-      showToast("Handle updated successfully", "success");
+      showToast("Updated", "success");
     } else {
-      showToast(response.message || "Failed to update handle", "error");
+      showToast(response.message || "Could not update", "error");
     }
     setIsEditing(false);
     router.refresh();
   };
+
   return (
-    <>
-      <Dialog
-        onOpenChange={(e) => {
-          if (e === false) {
-            setIsEditing(false);
-          }
-        }}
-        modal
-        open={isEditing}
-      >
-        <DialogTrigger asChild>
-          <Button onClick={() => setIsEditing(true)} variant="outline">
-            Edit
-          </Button>
-        </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Edit {handle.platform.title}</DialogTitle>
-            <DialogDescription>Make changes to your profile here. Click save when you&apos;re done.</DialogDescription>
-          </DialogHeader>
-          <EditSocialForm handle={handle} handleSave={handleSave}/>
-        </DialogContent>
-      </Dialog>
-    </>
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) setIsEditing(false);
+      }}
+      modal
+      open={isEditing}
+    >
+      <DialogTrigger asChild>
+        <Button onClick={() => setIsEditing(true)} variant="outline" size="sm">
+          Edit
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Edit {handle.platform.title}</DialogTitle>
+          <DialogDescription>Change the handle, then save.</DialogDescription>
+        </DialogHeader>
+        <EditSocialForm handle={handle} handleSave={handleSave} />
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/app/components/ui/userSocialCard/userSocialCard.tsx
+++ b/src/app/components/ui/userSocialCard/userSocialCard.tsx
@@ -1,49 +1,27 @@
 import Image from "next/image";
 import { USER_SOCIAL } from "@/app/models/socials";
-import React from "react";
 import EditUserCard from "./editUserCard";
 import DeleteUserCard from "./deleteUserCard";
 import CopyToClipBoard from "../copyToClipBoard/copyToClipBoard";
 
 const UserSocialCard = ({ handle }: { handle: USER_SOCIAL }) => {
+  const href = `${handle?.platform.socialBaseUrl}${handle?.handle}`;
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden ">
-      <div className="p-4 flex flex-col items-start">
-        {/* Header with Logo and Title */}
-        <div className="flex items-center mb-4 w-full">
-          {handle?.platform.socialLogo && (
-            <Image
-              src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handle?.platform.socialLogo}`}
-              alt={handle?.platform.title}
-              width={40}
-              height={40}
-              className="mr-3 rounded-full"
-              //   onError={(e) => {
-              //     (e.target as HTMLImageElement).src = "/fallback-logo.png"; // Use fallback image if logo fails to load
-              //   }}
-            />
-          )}
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{handle?.platform.title}</h2>
+    <div className="flex flex-col gap-3 rounded-2xl border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+      <a href={href} target="_blank" rel="noopener noreferrer" className="flex min-w-0 items-center gap-3">
+        {handle?.platform.socialLogo && (
+          <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handle?.platform.socialLogo}`} alt="" width={36} height={36} className="rounded-full" />
+        )}
+        <div className="min-w-0">
+          <p className="font-medium leading-tight">{handle?.platform.title}</p>
+          <p className="truncate text-sm text-muted-foreground">{handle?.handle}</p>
         </div>
-
-        {/* Handle and Link */}
-        <p className="text-gray-700 dark:text-gray-300 mb-2">
-          <strong>Handle:</strong> {handle?.handle}
-        </p>
-        <p className="text-gray-700 dark:text-gray-300 mb-4">
-          <a href={`${handle?.platform.socialBaseUrl}${handle?.handle}`} className="text-blue-500 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">
-            {handle?.platform.socialBaseUrl}
-            {handle?.handle}
-          </a>
-        </p>
-
-        <div className="flex gap-2">
-          <EditUserCard handle={handle} />
-
-          <DeleteUserCard handle={handle} />
-
-          <CopyToClipBoard text={handle.platform.socialBaseUrl + handle.handle} />
-        </div>
+      </a>
+      <div className="flex shrink-0 gap-2">
+        <CopyToClipBoard text={href} />
+        <EditUserCard handle={handle} />
+        <DeleteUserCard handle={handle} />
       </div>
     </div>
   );

--- a/src/app/components/ui/userSocialCard/userSocialCard.tsx
+++ b/src/app/components/ui/userSocialCard/userSocialCard.tsx
@@ -3,27 +3,37 @@ import { USER_SOCIAL } from "@/app/models/socials";
 import EditUserCard from "./editUserCard";
 import DeleteUserCard from "./deleteUserCard";
 import CopyToClipBoard from "../copyToClipBoard/copyToClipBoard";
+import { ArrowUpRight } from "lucide-react";
 
 const UserSocialCard = ({ handle }: { handle: USER_SOCIAL }) => {
   const href = `${handle?.platform.socialBaseUrl}${handle?.handle}`;
 
   return (
-    <div className="flex flex-col gap-3 rounded-2xl border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
-      <a href={href} target="_blank" rel="noopener noreferrer" className="flex min-w-0 items-center gap-3">
-        {handle?.platform.socialLogo && (
-          <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handle?.platform.socialLogo}`} alt="" width={36} height={36} className="rounded-full" />
-        )}
-        <div className="min-w-0">
-          <p className="font-medium leading-tight">{handle?.platform.title}</p>
-          <p className="truncate text-sm text-muted-foreground">{handle?.handle}</p>
-        </div>
-      </a>
-      <div className="flex shrink-0 gap-2">
+    <article className="group rounded-2xl border bg-card p-4 shadow-sm transition-shadow hover:shadow-md">
+      <div className="flex items-start gap-3">
+        <a href={href} target="_blank" rel="noopener noreferrer" className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted">
+            {handle?.platform.socialLogo ? (
+              <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${handle.platform.socialLogo}`} alt="" width={28} height={28} className="rounded-md" />
+            ) : (
+              <span className="text-sm font-medium">{handle?.platform.title?.[0]}</span>
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="flex items-center gap-1 font-medium leading-tight">
+              {handle?.platform.title}
+              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+            </p>
+            <p className="mt-0.5 truncate text-sm text-muted-foreground">{handle?.handle}</p>
+          </div>
+        </a>
+      </div>
+      <div className="mt-4 flex gap-2 border-t pt-3">
         <CopyToClipBoard text={href} />
         <EditUserCard handle={handle} />
         <DeleteUserCard handle={handle} />
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,17 +1,20 @@
 "use client";
+
 import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
 
 const Error = () => {
-  const handleRefresh = () => {
-    window.location.reload();
-  };
+  const router = useRouter();
   return (
-    <div className="h-screen flex items-center justify-center flex-col">
-      <h3>Oops! Something went wrong</h3>
-      <p>Try refreshing the page</p>
-      <Button  onClick={handleRefresh} className="mt-4">
-        Go back to home
-      </Button>
+    <div className="flex min-h-[70vh] flex-col items-center justify-center px-4 text-center">
+      <h1 className="text-xl font-semibold tracking-tight">Something went wrong</h1>
+      <p className="mt-2 text-sm text-muted-foreground">Refresh, or go back home.</p>
+      <div className="mt-6 flex gap-2">
+        <Button variant="outline" onClick={() => window.location.reload()}>
+          Refresh
+        </Button>
+        <Button onClick={() => router.push("/")}>Home</Button>
+      </div>
     </div>
   );
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,58 +4,26 @@
 
 @layer base {
   :root {
-    --background: 0 0% 98%; /* Very light grey background for a clean look */
-    --foreground: 220 15% 20%; /* Dark grey for text */
-    --card: 0 0% 100%; /* White for cards */
-    --card-foreground: 220 15% 20%; /* Dark grey for card text */
-    --popover: 0 0% 100%; /* White for popovers */
-    --popover-foreground: 220 15% 20%; /* Dark grey for popover text */
-    --primary: 210 60% 50%; /* Fresh, modern blue for primary elements */
-    --primary-foreground: 0 0% 100%; /* White for primary text */
-    --secondary: 210 16% 93%; /* Light grey for secondary elements */
-    --secondary-foreground: 220 15% 20%; /* Dark grey for secondary text */
-    --muted: 210 16% 93%; /* Very light grey for muted elements */
-    --muted-foreground: 220 8% 46%; /* Medium grey for muted text */
-    --accent: 175 65% 45%; /* Soft, vibrant teal for accent elements */
-    --accent-foreground: 0 0% 100%; /* White for accent text */
-    --destructive: 0 70% 50%; /* Desaturated red for destructive actions */
-    --destructive-foreground: 0 0% 100%; /* White for destructive text */
-    --border: 210 20% 85%; /* Light grey for borders */
-    --input: 210 20% 95%; /* Very light grey for inputs */
-    --ring: 210 60% 50%; /* Fresh, modern blue for focus rings */
-    --radius: 0.5rem; /* Default border radius */
-    --chart-1: 210 60% 50%; /* Fresh blue for charts */
-    --chart-2: 175 65% 45%; /* Vibrant teal for charts */
-    --chart-3: 30 100% 60%; /* Soft yellow for charts */
-    --chart-4: 340 65% 65%; /* Soft coral for charts */
-    --chart-5: 10 65% 65%; /* Soft red for charts */
-  }
-
-  .dark {
-    --background: 220 15% 15%; /* Dark grey for dark mode background */
-    --foreground: 0 0% 100%; /* White for dark mode text */
-    --card: 220 15% 20%; /* Dark grey for cards */
-    --card-foreground: 0 0% 100%; /* White for card text */
-    --popover: 220 15% 20%; /* Dark grey for popovers */
-    --popover-foreground: 0 0% 100%; /* White for popover text */
-    --primary: 210 60% 70%; /* Light blue for primary elements in dark mode */
-    --primary-foreground: 0 0% 10%; /* Very dark grey for primary text in dark mode */
-    --secondary: 0 0% 25%; /* Very dark grey for secondary elements */
-    --secondary-foreground: 0 0% 100%; /* White for secondary text */
-    --muted: 0 0% 35%; /* Dark grey for muted elements */
-    --muted-foreground: 0 0% 80%; /* Light grey for muted text */
-    --accent: 175 60% 50%; /* Soft teal for accent elements in dark mode */
-    --accent-foreground: 0 0% 100%; /* White for accent text */
-    --destructive: 0 60% 40%; /* Muted red for destructive actions */
-    --destructive-foreground: 0 0% 100%; /* White for destructive text */
-    --border: 0 0% 35%; /* Dark grey for borders */
-    --input: 0 0% 35%; /* Very dark grey for inputs */
-    --ring: 210 60% 70%; /* Light blue for focus rings in dark mode */
-    --chart-1: 210 60% 50%; /* Fresh blue for charts */
-    --chart-2: 175 60% 45%; /* Soft teal for charts */
-    --chart-3: 30 100% 60%; /* Soft yellow for charts */
-    --chart-4: 340 60% 65%; /* Soft coral for charts */
-    --chart-5: 10 60% 65%; /* Soft red for charts */
+    --background: 40 20% 99%;
+    --foreground: 24 10% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 24 10% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 24 10% 10%;
+    --primary: 24 10% 10%;
+    --primary-foreground: 40 20% 99%;
+    --secondary: 40 12% 96%;
+    --secondary-foreground: 24 10% 10%;
+    --muted: 40 12% 96%;
+    --muted-foreground: 24 6% 42%;
+    --accent: 40 12% 96%;
+    --accent-foreground: 24 10% 10%;
+    --destructive: 0 72% 46%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 30 10% 90%;
+    --input: 30 10% 90%;
+    --ring: 24 10% 10%;
+    --radius: 0.85rem;
   }
 }
 
@@ -63,7 +31,13 @@
   * {
     @apply border-border;
   }
+
+  html,
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+  }
+
+  body {
+    @apply min-h-screen;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ import { Providers } from "./components/layout/providers";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
-  title: "Socials",
-  description: "All your socials in one place",
+  title: "socials",
+  description: "All your socials in one simple public page. Add your handles and share a single link.",
   generator: "Next.js",
   manifest: "/manifest.json"
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,16 @@
-import { Poppins } from "next/font/google";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import Navbar from "@components/layout/navbar/navbar";
-// import NavigationMobile from "./components/layout/navbar/mobile/navbarMobile";
 import { Toaster } from "react-hot-toast";
-const poppins = Poppins({ weight: ["100", "200", "300", "400", "500", "600", "700", "800"], subsets: ["latin", "latin-ext"] });
+import { Providers } from "./components/layout/providers";
+
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
   title: "Socials",
   description: "All your socials in one place",
   generator: "Next.js",
-  manifest: "/manifest.json",
-  // keywords: ["nextjs", "nextjs14", "next14", "pwa", "next-pwa"],
-  // themeColor: [{ media: "(prefers-color-scheme: dark)", color: "#fff" }],
-  // authors: [
-  //   { name: "Alldo Faiz Ramadhani" },
-  //   {
-  //     name: "Alldo Faiz Ramadhani",
-  //     url: "https://www.linkedin.com/in/alldofaiz/"
-  //   }
-  // ],
-  // viewport: "minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, viewport-fit=cover",
-  // icons: [
-  //   { rel: "apple-touch-icon", url: "icons/icon-128x128.png" },
-  //   { rel: "icon", url: "icons/icon-128x128.png" }
-  // ]
+  manifest: "/manifest.json"
 };
 
 export default function RootLayout({
@@ -33,11 +20,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${poppins.className} dark`}>
-        <Navbar />
-        {/* <NavigationMobile /> */}
-        {children}
-        <Toaster position="top-center" reverseOrder={false} />
+      <body className={`${inter.className} min-h-screen bg-background text-foreground`}>
+        <Providers>
+          <Navbar />
+          {children}
+          <Toaster position="top-center" reverseOrder={false} toastOptions={{ className: "text-sm" }} />
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-lg border border-input bg-card px-3.5 text-sm transition-colors placeholder:text-muted-foreground/80 focus-visible:outline-none focus-visible:border-foreground focus-visible:ring-2 focus-visible:ring-ring/15 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100",
           className
         )}
         ref={ref}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,21 @@ const config: Config = {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		keyframes: {
+  			"fade-up": {
+  				"0%": { opacity: "0", transform: "translateY(10px)" },
+  				"100%": { opacity: "1", transform: "translateY(0)" }
+  			},
+  			"press-pop": {
+  				"0%": { transform: "scale(1)" },
+  				"40%": { transform: "scale(0.985)" },
+  				"100%": { transform: "scale(1)" }
+  			}
+  		},
+  		animation: {
+  			"fade-up": "fade-up 0.55s ease-out both",
+  			"press-pop": "press-pop 0.35s ease-out"
   		}
   	}
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up UI work on current `master`. Light theme, clearer navigation, and a proper landing page.

## Changes
- Text wordmark (`socials`) instead of the image logo
- Landing page: what it is, a page preview, three how-it-works steps, and a sign-in CTA
- Cards: icon well, light shadow, hover, actions on their own row
- Forms: taller fields, labels, helper text, URL/`@` prefixes; `@` is stripped from handles

## Verification
- `npx tsc --noEmit` and `npx next lint` passed
- `npx vitest run` passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a79c360-c535-4949-99c9-74ba5ffbcbda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a79c360-c535-4949-99c9-74ba5ffbcbda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

