### PR TITLE
Fix choose-socials crash on Mongoose social documents

### DIFF
--- a/src/app/components/ui/socialCard/socialCard.tsx
+++ b/src/app/components/ui/socialCard/socialCard.tsx
@@ -18,7 +18,7 @@ const SocialCard = ({ title, socialLogo, _id }: SocialCardProps) => {
         {socialLogo ? (
           <Image src={`${process.env.NEXT_PUBLIC_CDN_URL}/${socialLogo}`} alt="" height={28} width={28} className="rounded-md" />
         ) : (
-          <span className="text-sm font-medium">{title[0]}</span>
+          <span className="text-sm font-medium">{title?.[0] ?? "?"}</span>
         )}
       </div>
       <span className="flex-1 font-medium">{title}</span>

--- a/src/app/components/ui/socialCard/toSocialCardProps.test.ts
+++ b/src/app/components/ui/socialCard/toSocialCardProps.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { toSocialCardProps } from "./toSocialCardProps";
+
+describe("toSocialCardProps", () => {
+  it("reads schema fields from a mongoose-like object that does not spread", () => {
+    const document = Object.create({
+      _id: { toString: () => "abc" },
+      title: "GitHub",
+      socialLogo: "socials/github.png"
+    });
+
+    expect({ ...document }).toEqual({});
+    expect(toSocialCardProps(document)).toEqual({
+      _id: "abc",
+      title: "GitHub",
+      socialLogo: "socials/github.png"
+    });
+  });
+
+  it("does not throw when title is missing", () => {
+    expect(toSocialCardProps({})).toEqual({ _id: "", title: "", socialLogo: "" });
+  });
+});

--- a/src/app/components/ui/socialCard/toSocialCardProps.ts
+++ b/src/app/components/ui/socialCard/toSocialCardProps.ts
@@ -1,0 +1,11 @@
+export function toSocialCardProps(social: {
+  _id?: { toString(): string } | string;
+  title?: string;
+  socialLogo?: string;
+}) {
+  return {
+    _id: social._id ? String(social._id) : "",
+    title: social.title ?? "",
+    socialLogo: social.socialLogo ?? ""
+  };
+}

--- a/src/app/components/ui/socialsList/socialsList.tsx
+++ b/src/app/components/ui/socialsList/socialsList.tsx
@@ -2,6 +2,7 @@ import { Social } from "@/app/models/socials";
 import { dbConnect } from "@/lib/db/mongoose";
 import { getDefaultSocials } from "@/lib/services/socials";
 import SocialCard from "../socialCard/socialCard";
+import { toSocialCardProps } from "../socialCard/toSocialCardProps";
 import { PageShell } from "@/app/components/layout/pageShell";
 import Link from "next/link";
 
@@ -26,7 +27,7 @@ const SocialsList = async () => {
       ) : (
         <div className="space-y-3">
           {data.map((social: Social) => (
-            <SocialCard key={social._id} {...social} />
+            <SocialCard key={social._id} {...toSocialCardProps(social)} />
           ))}
         </div>
       )}

--- a/src/lib/services/socials.test.ts
+++ b/src/lib/services/socials.test.ts
@@ -24,13 +24,15 @@ describe("social services", () => {
   });
 
   it("lists default socials", async () => {
-    vi.mocked(Socials.find).mockResolvedValue([{ title: "X" }] as never);
+    const lean = vi.fn().mockResolvedValue([{ title: "X" }]);
+    vi.mocked(Socials.find).mockReturnValue({ lean } as never);
 
     await expect(getDefaultSocials()).resolves.toEqual({ status: 200, body: [{ title: "X" }] });
   });
 
   it("returns 404 when a social is missing", async () => {
-    vi.mocked(Socials.findById).mockResolvedValue(null);
+    const lean = vi.fn().mockResolvedValue(null);
+    vi.mocked(Socials.findById).mockReturnValue({ lean } as never);
 
     await expect(getSocialById("missing")).resolves.toEqual({
       status: 404,

--- a/src/lib/services/socials.ts
+++ b/src/lib/services/socials.ts
@@ -12,7 +12,7 @@ export async function createSocial(input: Record<string, unknown>): Promise<Serv
 
 export async function getDefaultSocials(): Promise<ServiceResult<unknown>> {
   try {
-    const socials = await Socials.find();
+    const socials = await Socials.find().lean();
     return { status: 200, body: socials };
   } catch (error: unknown) {
     return { status: 500, body: { error: errorMessage(error) } };
@@ -21,7 +21,7 @@ export async function getDefaultSocials(): Promise<ServiceResult<unknown>> {
 
 export async function getSocialById(id: string): Promise<ServiceResult<unknown>> {
   try {
-    const social = await Socials.findById(id);
+    const social = await Socials.findById(id).lean();
     if (!social) {
       return { status: 404, body: { message: "Social not found" } };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `TypeError: Cannot read properties of undefined (reading '0')` on `/choose-socials`.

Spreading a Mongoose document into `SocialCard` dropped `title` and `socialLogo`, so the fallback `title[0]` crashed. Cards now read those fields explicitly, and the socials queries return lean documents.

## Verification
- `npx vitest run src/app/components/ui/socialCard/toSocialCardProps.test.ts src/lib/services/socials.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a79c360-c535-4949-99c9-74ba5ffbcbda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a79c360-c535-4949-99c9-74ba5ffbcbda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

